### PR TITLE
slim: examples+docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,69 @@ TBD.
 
 ## Usage
 
-TBD.
+### Types
+
+This library provides support for different types:
+
+- minimal => fix, feat
+- conventional => build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test
+- falco => build, ci, chore, docs, feat, fix, perf, new, revert, update, test, rule
+
+At the moment, those types are static and cannot be configured.
 
 ### Options
 
-TBD.
+Every parser has its own options.
+
+You can set them calling a function on the parser machine. Or you can provide options to `NewMachine(...)` directly.
+
+### Parse only the first line
+
+Your code base uses only single line commit messages like this one?
+
+```console
+feat: awesomeness
+```
+
+It's the perfect case for the **slim** parser:
+
+```go
+m, _ := slim.NewMachine().Parse([]byte(`feat: awesomeness`))
+```
+
+### Parse only the first line ignoring the commit message body
+
+Imagine you have a commit message like this:
+
+```console
+fix: correct minor typos in code
+
+see the issue for details
+
+on typos fixed.
+
+Reviewed-by: Z
+Refs #133
+```
+
+And you want to parse only the first line of your commits ignoring its body for some reason...
+
+Go with this:
+
+```go
+opts := []conventionalcommits.MachineOption{
+    WithBestEffort(),
+    WithTypes(conventionalcommits.TypesConventional),
+}
+res, err := slim.NewMachine(opts...).Parse(i)
+```
+
+The best effort mode will make the parser return what it found until the point it errored out (ie., the first newline in this case),
+if it found (at least) a valid type and a description (eg., `fix: description`).
+
+The parser will still return the error (with the position information), so that you can eventually use it.
+
+You can see this in action [here](slim/example_test.go).
 
 ## Performances
 

--- a/conventional_commit.go
+++ b/conventional_commit.go
@@ -50,6 +50,8 @@ type Message interface {
 }
 
 // Minimal represent a base struct for Conventional Commit messages.
+//
+// It has nothing to do with the types in use by the parser.
 type Minimal struct {
 	Type        string
 	Description string

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/leodido/go-conventionalcommits
 go 1.14
 
 require (
+	github.com/davecgh/go-spew v1.1.1
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.6.1

--- a/slim/example_test.go
+++ b/slim/example_test.go
@@ -1,0 +1,80 @@
+package slim
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/leodido/go-conventionalcommits"
+)
+
+func output(out interface{}) {
+	spew.Config.DisableCapacities = true
+	spew.Config.DisablePointerAddresses = true
+	spew.Dump(out)
+}
+
+func Example_minimal_withoutbody() {
+	i := []byte(`fix!: something`)
+	m, _ := NewMachine().Parse(i)
+	output(m)
+	fmt.Println("there are breaking changes?", m.IsBreakingChange())
+	// Output:
+	// (*slim.ConventionalCommit)({
+	//  Minimal: (conventionalcommits.Minimal) {
+	//   Type: (string) (len=3) "fix",
+	//   Description: (string) (len=9) "something",
+	//   Scope: (*string)(<nil>),
+	//   Exclamation: (bool) true
+	//  }
+	// })
+	// there are breaking changes? true
+}
+
+func Example_conventional_ignoringbody() {
+	i := []byte(`fix: correct minor typos in code
+
+see the issue for details
+on typos fixed.
+
+Reviewed-by: Z
+Refs #133`)
+
+	opts := []conventionalcommits.MachineOption{
+		WithBestEffort(),
+		WithTypes(conventionalcommits.TypesConventional),
+	}
+	m, e := NewMachine(opts...).Parse(i)
+	output(m)
+	fmt.Println("is result ok?", m.Ok())
+
+	errstr := e.Error()
+	fmt.Println(errstr)
+	pos := strings.LastIndex(errstr, "=")
+	num, _ := strconv.Atoi(errstr[pos+1 : len(errstr)])
+	// Not checking pos and num because ain't time for bs
+	fmt.Printf("parsing ok until position %d\n", num)
+	fmt.Println("ignored body:")
+	fmt.Println(string(i[num:len(i)]))
+
+	// Output:
+	// (*slim.ConventionalCommit)({
+	//  Minimal: (conventionalcommits.Minimal) {
+	//   Type: (string) (len=3) "fix",
+	//   Description: (string) (len=27) "correct minor typos in code",
+	//   Scope: (*string)(<nil>),
+	//   Exclamation: (bool) false
+	//  }
+	// })
+	// is result ok? true
+	// illegal newline: col=33
+	// parsing ok until position 33
+	// ignored body:
+	//
+	// see the issue for details
+	// on typos fixed.
+	//
+	// Reviewed-by: Z
+	// Refs #133
+}

--- a/slim/machine.go.rl
+++ b/slim/machine.go.rl
@@ -247,6 +247,7 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 	}
 	%% write exec;
 
+	// Not checking m.bestEffort too because I want to emit ErrNewline in best effort mode
 	if m.newline {
 		m.err = m.emitErrorWithoutCharacter(ErrNewline);
 	}

--- a/slim/options.go
+++ b/slim/options.go
@@ -6,6 +6,9 @@ import (
 )
 
 // WithBestEffort enables the best effort mode.
+//
+// Best effort mode tells the parser to return what it found,
+// if the input was a minimally well-formed commit message (type and description part).
 func WithBestEffort() conventionalcommits.MachineOption {
 	return func(m conventionalcommits.Machine) conventionalcommits.Machine {
 		m.WithBestEffort()


### PR DESCRIPTION
This PR adds examples regarding the **slim** conventional commits parser.