### PR TITLE
ci: add Reviewpad action

### DIFF
--- a/.github/workflows/reviewpad.yml
+++ b/.github/workflows/reviewpad.yml
@@ -1,0 +1,29 @@
+name: Reviewpad
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - edited
+      - review_requested
+      - review_request_removed
+  pull_request_review:
+  pull_request_review_comment:
+
+jobs:
+  reviewpad_job:
+    runs-on: ubuntu-latest
+    name: Reviewpad
+    steps:
+      # Run Reviewpad on all new Issues and Pull Requests! 🦄
+      - name: Reviewpad
+        uses: reviewpad/action@v3.x
+        with:
+          # Uses a default Reviewpad configuration file to get your started.
+          # For customization and documentation, see https://github.com/reviewpad/action
+          file_url: https://github.com/reviewpad/action/blob/main/templates/start.yml

--- a/.github/workflows/reviewpad.yml
+++ b/.github/workflows/reviewpad.yml
@@ -15,6 +15,10 @@ on:
   pull_request_review:
   pull_request_review_comment:
 
+permissions:
+  pull-requests: write
+  issues: write
+
 jobs:
   reviewpad_job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request adds the Reviewpad GitHub action to help automating some workflows around pull requests.

At the moment, it uses the default start template that will simply add a label to the pull request based on the size of the diff. 

The template will grow so that it will also do things like check for conventional commits in the pull requests of these repositories (similarly to what is done in https://github.com/reviewpad/reviewpad/blob/main/reviewpad.yml#L297).

Happy to receive feedback on this proposal!