### PR TITLE
fix!: change return type on Parse method

### DIFF
--- a/conventional_commit.go
+++ b/conventional_commit.go
@@ -51,7 +51,7 @@ type Logger interface {
 
 // Machine represent a FSM able to parse a conventional commit and return it in an structured way.
 type Machine interface {
-	Parse(input []byte) (Message, error)
+	Parse(input []byte) (*ConventionalCommit, error)
 	BestEfforter
 	TypeConfigurer
 	Logger

--- a/parser/conventional_commit.go
+++ b/parser/conventional_commit.go
@@ -23,7 +23,7 @@ func (c *conventionalCommit) minimal() bool {
 	return c._type != "" && c.descr != ""
 }
 
-func (c *conventionalCommit) export() conventionalcommits.Message {
+func (c *conventionalCommit) export() *conventionalcommits.ConventionalCommit {
 	out := &conventionalcommits.ConventionalCommit{}
 	out.Exclamation = c.exclamation
 	out.Type = strings.ToLower(c._type)

--- a/parser/machine.go
+++ b/parser/machine.go
@@ -127,7 +127,7 @@ func NewMachine(options ...conventionalcommits.MachineOption) conventionalcommit
 //
 // It can also partially parse input messages returning a partially valid structured representation
 // and the error that stopped the parsing.
-func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
+func (m *machine) Parse(input []byte) (*conventionalcommits.ConventionalCommit, error) {
 	m.data = input
 	m.p = 0
 	m.pb = 0

--- a/parser/machine.go.rl
+++ b/parser/machine.go.rl
@@ -384,7 +384,7 @@ func NewMachine(options ...conventionalcommits.MachineOption) conventionalcommit
 //
 // It can also partially parse input messages returning a partially valid structured representation
 // and the error that stopped the parsing.
-func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
+func (m *machine) Parse(input []byte) (*conventionalcommits.ConventionalCommit, error) {
 	m.data = input
 	m.p = 0
 	m.pb = 0

--- a/parser/testcases.go
+++ b/parser/testcases.go
@@ -14,8 +14,8 @@ type testCase struct {
 	title        string
 	input        []byte
 	ok           bool
-	value        conventionalcommits.Message
-	partialValue conventionalcommits.Message
+	value        *conventionalcommits.ConventionalCommit
+	partialValue *conventionalcommits.ConventionalCommit
 	errorString  string
 	bump         *conventionalcommits.VersionBump
 }


### PR DESCRIPTION
Changes the return type on the `Machine.Parse` method to return a ConventionalCommit object. This gives the type system more information on the properties available.

We still get the type information from the `Message` interface because ConventionalCommit implements Message so no functionality is lost. However this does change the return types for all consumers using the Parse method.

BREAKING CHANGE: `Machine.Parse()` method now returns ConventionalCommit object instead of Message
Resolves: #36