### PR TITLE
chore(devcontainer): install ragel + graphviz, add Go 1.24

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends ragel graphviz \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+	"name": "go-conventionalcommits",
+	"build": {
+		"context": ".",
+		"dockerfile": "Dockerfile"
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/go": {
+			"version": "1.24"
+		}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"golang.go"
+			]
+		}
+	}
+}


### PR DESCRIPTION
Mirrors the `.devcontainer/` setup from [`leodido/go-syslog@develop`](https://github.com/leodido/go-syslog/tree/develop/.devcontainer) so contributors get a working environment for this repo's build pipeline out of the box. Bumps the Go feature to 1.24.

### What was missing

The repo's `.devcontainer/` was the empty Ona default. It did not provide:

- **ragel** — required by `make build` to regenerate `parser/machine.go` from `parser/machine.go.rl` (README explicitly calls out Ragel 6.10).
- **graphviz (`dot`)** — required by `make docs` to render `parser/docs/*.png` FSM diagrams.
- **Go toolchain** — `go.mod` declares `go 1.21` but the base image ships none.

### Changes

- `.devcontainer/Dockerfile`: `mcr.microsoft.com/devcontainers/base:ubuntu-24.04` + `apt-get install -y ragel graphviz`.
- `.devcontainer/devcontainer.json`: `ghcr.io/devcontainers/features/go` pinned to `1.24`, plus the `golang.go` VS Code extension.

### Verified end-to-end in the rebuilt container

```
$ ragel --version | head -1
Ragel State Machine Compiler version 6.10 March 2017
$ dot -V
dot - graphviz version 2.43.0 (0)
$ go version
go version go1.24.13 linux/amd64

$ make clean && make build   # regenerates parser/machine.go byte-identical to HEAD
$ make tests                  # PASS
$ make docs                   # all 7 FSM .dot/.png files rendered
```

Co-authored-by: Ona <no-reply@ona.com>