### PR TITLE
chore(devcontainer): neutralize `prepare-commit-msg` hooks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,5 +15,6 @@
 				"golang.go"
 			]
 		}
-	}
+	},
+	"postCreateCommand": "git config core.hooksPath .githooks && go mod download"
 }

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Intentionally empty.
+#
+# This hook exists to neutralize any prepare-commit-msg hook that an editor,
+# IDE plugin, or AI tool may try to install (for example, by appending a
+# trailer to the commit message or rewriting its content).
+#
+# core.hooksPath is set to .githooks (see the devcontainer postCreateCommand),
+# which makes Git look here instead of .git/hooks/, so anything dropped into
+# .git/hooks/prepare-commit-msg is bypassed entirely.
+#
+# Do not add logic here. If you need a real prepare-commit-msg hook, create
+# a new repo-tracked one with a clear, intentional purpose.
+exit 0


### PR DESCRIPTION
Follow-up to #40. Stops editors, IDE plugins, and AI tools from being able to silently inject content into commit messages via `.git/hooks/prepare-commit-msg`.

### What it does

- **Adds `.githooks/prepare-commit-msg`** — intentionally empty (shebang + `exit 0`). Repo-tracked, executable, no logic. The doc comment explains why.
- **Adds `postCreateCommand` to `.devcontainer/devcontainer.json`**:

  ```jsonc
  "postCreateCommand": "git config core.hooksPath .githooks && go mod download"
  ```

  The first half makes Git look in `.githooks/` instead of `.git/hooks/`. Anything dropped into `.git/hooks/prepare-commit-msg` is then bypassed entirely. The second half warms the module cache so the first `go test` / `go build` is fast.

### Why an "empty" hook needs a shebang

A literal zero-byte executable file fails `exec()` with "Exec format error" on most systems and **aborts the commit**. To be a true no-op, the file needs at least `#!/usr/bin/env bash` + `exit 0`.

### Why `core.hooksPath` instead of `chmod -x` on `.git/hooks/prepare-commit-msg`

`.git/` is local-only. A repo-wide policy has to ship in version control, which means it must redirect to a tracked location — `.githooks/`.

### Verified end-to-end

Planted a sabotage hook at `.git/hooks/prepare-commit-msg`:

```bash
#!/usr/bin/env bash
echo "[BAD HOOK ran! Should NOT happen!] tampering" >> "$1"
```

Made a real commit with `core.hooksPath=.githooks` active. The trailer **did not** appear in the commit message — `.githooks/prepare-commit-msg` (`exit 0`) was used instead. Git found `.githooks/` first and never consulted `.git/hooks/`.

### Notes

- This was originally bundled into #40 but the PR was merged before the amendment landed; this PR ships the hook half cleanly off the new `develop`.
- For contributors who don't use the devcontainer, the hook policy is opt-in. They can run `git config core.hooksPath .githooks` once locally to get the same protection. Could be added to the README later if desired.