### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.24'
           check-latest: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.24'
           check-latest: true
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
         with:
           version: v2.11.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0 # Avoid running against a shallow clone
 
@@ -25,13 +25,13 @@ jobs:
         run: git fetch --force --tags
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.24'
           check-latest: true
 
       - name: Release
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: '~> v2'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Check out the source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go ${{ matrix.go }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ matrix.go }}
           check-latest: true
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.go == '1.24' && github.ref == 'refs/heads/develop'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           files: ./coverage.out
           fail_ci_if_error: false


### PR DESCRIPTION
Replace floating major-version tags (e.g. `@v4`) on every workflow `uses:` line with full commit SHAs plus a version comment, so workflow runs are reproducible and immune to tag movement or compromise of upstream actions.

## Pinned actions

| Action | Pin |
| --- | --- |
| `actions/checkout` | `@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1` |
| `actions/setup-go` | `@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0` |
| `codecov/codecov-action` | `@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0` |
| `golangci/golangci-lint-action` | `@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1` |
| `goreleaser/goreleaser-action` | `@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0` |

All five SHAs were resolved against the GitHub API and verified to exist in the upstream repos.

## Scope

- Touches only the four workflow files: `build.yml`, `lint.yml`, `release.yml`, `test.yml`
- 11 `uses:` lines rewritten total
- No behavioural change — pins resolve to the same commits the floating tags currently point at

## Notes

- Codecov is intentionally kept on v4 (latest v4 patch is v4.6.0). Bump to v5 deferred to a separate PR.
- Pin comment style is `@<sha> # vX.Y.Z` to keep the version legible in diffs and for future bumps.
- No Dependabot config added in this PR.