### PR TITLE
ci: bump codecov-action v4 -> v5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.go == '1.24' && github.ref == 'refs/heads/develop'
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           files: ./coverage.out
           fail_ci_if_error: false


### PR DESCRIPTION
Bump the coverage upload step from `codecov/codecov-action` v4.6.0 to v5.5.4 (latest v5 patch). `v5` wraps the [Codecov CLI](https://github.com/codecov/codecov-cli) via the [Codecov Wrapper](https://github.com/codecov/wrapper), which receives updates faster than the v4 uploader binary.

## Pin

```
codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
```

SHA resolved against the GitHub API and dereferenced from the annotated tag to the underlying commit.

## v4 → v5 compatibility

Per the [v5.0.0 release notes](https://github.com/codecov/codecov-action/releases/tag/v5.0.0), only two inputs were affected:

- `file` → deprecated in favour of `files`
- `plugin` → deprecated in favour of `plugins`

This workflow already uses `files`, so no input changes are required. Token wiring (`CODECOV_TOKEN` via `env:`), the `if:` guard (`matrix.go == '1.24' && github.ref == 'refs/heads/develop'`) and `fail_ci_if_error: false` are all unchanged.

## Notes

- v5 has been GA for a while (v5.5.4 is current); v6.0.0 was just released — keeping that for a separate PR if/when desired.
- One-line diff in `.github/workflows/test.yml`.