### PR TITLE
fix(parser): handle trailer-looking lines in body

### DIFF
--- a/parser/contract_test.go
+++ b/parser/contract_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2020- Leonardo Di Donato <leodidonato@gmail.com>
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/leodido/go-conventionalcommits"
+)
+
+// TestParseNeverReturnsNilNil pins the Parse contract:
+//
+//	(message, error) := Parse(input)
+//	=> message != nil OR error != nil
+//
+// A `(nil, nil)` return makes callers nil-deref on the second
+// branch of the canonical pattern:
+//
+//	m, err := p.Parse(in)
+//	if err != nil { return err }
+//	if !m.Ok() { ... }   // <- NPE here
+//
+// The trailing-CRLF input below historically reached the strict-
+// mode return site with m.cs < first_final and m.err == nil. See
+// the second-pass review of PR #47.
+func TestParseNeverReturnsNilNil(t *testing.T) {
+	cases := []struct {
+		name  string
+		input []byte
+	}{
+		{
+			"trailing-CRLF-after-only-trailer",
+			[]byte("feat: x\n\nReviewed-by: Me\r\n"),
+		},
+		{
+			"trailing-CR-after-only-trailer",
+			[]byte("feat: x\n\nReviewed-by: Me\r"),
+		},
+		{
+			"trailing-CRLF-after-body-and-trailer",
+			[]byte("feat: x\n\nFixes #15\n\nbody text\n\nReviewed-by: Me\r\n"),
+		},
+	}
+	configs := []struct {
+		name string
+		opt  conventionalcommits.MachineOption
+	}{
+		{"minimal", WithTypes(conventionalcommits.TypesMinimal)},
+		{"conventional", WithTypes(conventionalcommits.TypesConventional)},
+		{"falco", WithTypes(conventionalcommits.TypesFalco)},
+		{"freeform", WithTypes(conventionalcommits.TypesFreeForm)},
+	}
+	for _, cfg := range configs {
+		for _, tc := range cases {
+			t.Run(cfg.name+"/"+tc.name, func(t *testing.T) {
+				m, err := NewMachine(cfg.opt).Parse(tc.input)
+				if m == nil && err == nil {
+					t.Fatalf("Parse contract violated: returned (nil, nil) for input %q", tc.input)
+				}
+			})
+			t.Run(cfg.name+"/"+tc.name+"/best-effort", func(t *testing.T) {
+				m, err := NewMachine(cfg.opt, WithBestEffort()).Parse(tc.input)
+				if m == nil && err == nil {
+					t.Fatalf("Parse contract violated (best-effort): returned (nil, nil) for input %q", tc.input)
+				}
+			})
+		}
+	}
+	// Sanity: a happy-path input must still return (non-nil, nil).
+	m, err := NewMachine().Parse([]byte("fix: x"))
+	assert.NotNil(t, m)
+	assert.NoError(t, err)
+}

--- a/parser/machine.go
+++ b/parser/machine.go
@@ -3683,6 +3683,29 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 			// An error occurred but partial parsing is on and partial message is minimally valid
 			return output.export(), m.err
 		}
+		// Defensive: a few FSM error transitions (e.g. a trailing CR
+		// after an otherwise-complete trailer) leave m.cs < firstFinal
+		// without ever assigning m.err. Returning (nil, nil) at this
+		// point silently violates Parse's contract and nil-derefs the
+		// canonical caller pattern:
+		//
+		//   m, err := p.Parse(in)
+		//   if err != nil { return err }
+		//   if !m.Ok() { ... }            // <- NPE here on (nil, nil)
+		//
+		// Synthesize an early-exit error from the current cursor so
+		// strict-mode Parse always returns either a message or an
+		// error, never both nil. The cursor may be at EOF (m.p == m.pe)
+		// when this fires, so report against the previous byte when one
+		// exists and against an empty character otherwise. See PR #47
+		// second-pass review (§3) and TestParseNeverReturnsNilNil.
+		if m.err == nil {
+			if m.p > 0 && m.p-1 < len(m.data) {
+				m.err = m.emitErrorOnPreviousCharacter(ErrEarly)
+			} else {
+				m.err = m.emitError(ErrEarly, "", m.p)
+			}
+		}
 		return nil, m.err
 	}
 

--- a/parser/machine.go
+++ b/parser/machine.go
@@ -69,6 +69,15 @@ func (m *machine) text() []byte {
 	return m.data[m.pb:m.p]
 }
 
+// shouldRedirectToBody is consulted by the startTrailerParsing Ragel
+// action to decide whether the next stretch of input should be parsed
+// as body content rather than the start of a footer trailer. Returning
+// false preserves the historical behavior (always enter trailer
+// parsing). The fix for issue #38 plugs its decision logic in here.
+func (m *machine) shouldRedirectToBody() bool {
+	return false
+}
+
 func (m *machine) emitInfo(s string, args ...interface{}) {
 	if m.logger != nil {
 		logEntry := logrus.NewEntry(m.logger)
@@ -545,6 +554,18 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		output.body += string(m.text())
 		m.emitInfo("valid commit message body content", "body", string(m.text()))
 
+		// shouldRedirectToBody centralizes the decision of whether the next
+		// stretch of input should be parsed as body content rather than as
+		// the start of a footer trailer. Keeping the predicate in Go (and
+		// the fgoto in Ragel) means the action body Ragel emits at every
+		// callsite stays one line of conditional + fgoto, so the generated
+		// machine.go does not multiply the predicate logic across callsites.
+		if m.shouldRedirectToBody() {
+			m.emitDebug("redirecting to body parsing", "pos", m.p)
+			{
+				goto st34
+			}
+		}
 		m.emitDebug("try to parse a footer trailer token", "pos", m.p)
 		{
 			goto st127
@@ -571,6 +592,18 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		// Do not advance over the current char
 		(m.p)--
 
+		// shouldRedirectToBody centralizes the decision of whether the next
+		// stretch of input should be parsed as body content rather than as
+		// the start of a footer trailer. Keeping the predicate in Go (and
+		// the fgoto in Ragel) means the action body Ragel emits at every
+		// callsite stays one line of conditional + fgoto, so the generated
+		// machine.go does not multiply the predicate logic across callsites.
+		if m.shouldRedirectToBody() {
+			m.emitDebug("redirecting to body parsing", "pos", m.p)
+			{
+				goto st34
+			}
+		}
 		m.emitDebug("try to parse a footer trailer token", "pos", m.p)
 		{
 			goto st127
@@ -728,6 +761,18 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 
 		m.emitDebug("found a blank line", "pos", m.p)
 
+		// shouldRedirectToBody centralizes the decision of whether the next
+		// stretch of input should be parsed as body content rather than as
+		// the start of a footer trailer. Keeping the predicate in Go (and
+		// the fgoto in Ragel) means the action body Ragel emits at every
+		// callsite stays one line of conditional + fgoto, so the generated
+		// machine.go does not multiply the predicate logic across callsites.
+		if m.shouldRedirectToBody() {
+			m.emitDebug("redirecting to body parsing", "pos", m.p)
+			{
+				goto st34
+			}
+		}
 		m.emitDebug("try to parse a footer trailer token", "pos", m.p)
 		{
 			goto st127
@@ -858,6 +903,18 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		m.lastNewline = m.p
 		m.emitDebug("found a newline", "pos", m.p)
 
+		// shouldRedirectToBody centralizes the decision of whether the next
+		// stretch of input should be parsed as body content rather than as
+		// the start of a footer trailer. Keeping the predicate in Go (and
+		// the fgoto in Ragel) means the action body Ragel emits at every
+		// callsite stays one line of conditional + fgoto, so the generated
+		// machine.go does not multiply the predicate logic across callsites.
+		if m.shouldRedirectToBody() {
+			m.emitDebug("redirecting to body parsing", "pos", m.p)
+			{
+				goto st34
+			}
+		}
 		m.emitDebug("try to parse a footer trailer token", "pos", m.p)
 		{
 			goto st127
@@ -871,6 +928,18 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		m.lastNewline = m.p
 		m.emitDebug("found a newline", "pos", m.p)
 
+		// shouldRedirectToBody centralizes the decision of whether the next
+		// stretch of input should be parsed as body content rather than as
+		// the start of a footer trailer. Keeping the predicate in Go (and
+		// the fgoto in Ragel) means the action body Ragel emits at every
+		// callsite stays one line of conditional + fgoto, so the generated
+		// machine.go does not multiply the predicate logic across callsites.
+		if m.shouldRedirectToBody() {
+			m.emitDebug("redirecting to body parsing", "pos", m.p)
+			{
+				goto st34
+			}
+		}
 		m.emitDebug("try to parse a footer trailer token", "pos", m.p)
 		{
 			goto st127
@@ -1125,6 +1194,18 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 
 		m.emitDebug("found a blank line", "pos", m.p)
 
+		// shouldRedirectToBody centralizes the decision of whether the next
+		// stretch of input should be parsed as body content rather than as
+		// the start of a footer trailer. Keeping the predicate in Go (and
+		// the fgoto in Ragel) means the action body Ragel emits at every
+		// callsite stays one line of conditional + fgoto, so the generated
+		// machine.go does not multiply the predicate logic across callsites.
+		if m.shouldRedirectToBody() {
+			m.emitDebug("redirecting to body parsing", "pos", m.p)
+			{
+				goto st34
+			}
+		}
 		m.emitDebug("try to parse a footer trailer token", "pos", m.p)
 		{
 			goto st127
@@ -1785,6 +1866,18 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 
 		m.emitDebug("found a blank line", "pos", m.p)
 
+		// shouldRedirectToBody centralizes the decision of whether the next
+		// stretch of input should be parsed as body content rather than as
+		// the start of a footer trailer. Keeping the predicate in Go (and
+		// the fgoto in Ragel) means the action body Ragel emits at every
+		// callsite stays one line of conditional + fgoto, so the generated
+		// machine.go does not multiply the predicate logic across callsites.
+		if m.shouldRedirectToBody() {
+			m.emitDebug("redirecting to body parsing", "pos", m.p)
+			{
+				goto st34
+			}
+		}
 		m.emitDebug("try to parse a footer trailer token", "pos", m.p)
 		{
 			goto st127
@@ -2358,6 +2451,18 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 
 		m.emitDebug("found a blank line", "pos", m.p)
 
+		// shouldRedirectToBody centralizes the decision of whether the next
+		// stretch of input should be parsed as body content rather than as
+		// the start of a footer trailer. Keeping the predicate in Go (and
+		// the fgoto in Ragel) means the action body Ragel emits at every
+		// callsite stays one line of conditional + fgoto, so the generated
+		// machine.go does not multiply the predicate logic across callsites.
+		if m.shouldRedirectToBody() {
+			m.emitDebug("redirecting to body parsing", "pos", m.p)
+			{
+				goto st34
+			}
+		}
 		m.emitDebug("try to parse a footer trailer token", "pos", m.p)
 		{
 			goto st127
@@ -3423,6 +3528,18 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 				output.body += string(m.text())
 				m.emitInfo("valid commit message body content", "body", string(m.text()))
 
+				// shouldRedirectToBody centralizes the decision of whether the next
+				// stretch of input should be parsed as body content rather than as
+				// the start of a footer trailer. Keeping the predicate in Go (and
+				// the fgoto in Ragel) means the action body Ragel emits at every
+				// callsite stays one line of conditional + fgoto, so the generated
+				// machine.go does not multiply the predicate logic across callsites.
+				if m.shouldRedirectToBody() {
+					m.emitDebug("redirecting to body parsing", "pos", m.p)
+					{
+						goto st34
+					}
+				}
 				m.emitDebug("try to parse a footer trailer token", "pos", m.p)
 				{
 					goto st127

--- a/parser/machine.go
+++ b/parser/machine.go
@@ -63,6 +63,13 @@ type machine struct {
 	currentFooterKey string
 	countNewlines    int
 	lastNewline      int
+	// trailerBlockStart is the byte offset (within data) at which the
+	// trailing footer trailer block begins, or -1 when no such block
+	// exists. It is computed exactly once at the start of Parse() and
+	// is consulted by shouldRedirectToBody to decide whether a given
+	// >startTrailerParsing entry should fall through to the body
+	// machine instead. See issue #38.
+	trailerBlockStart int
 }
 
 func (m *machine) text() []byte {
@@ -71,11 +78,60 @@ func (m *machine) text() []byte {
 
 // shouldRedirectToBody is consulted by the startTrailerParsing Ragel
 // action to decide whether the next stretch of input should be parsed
-// as body content rather than the start of a footer trailer. Returning
-// false preserves the historical behavior (always enter trailer
-// parsing). The fix for issue #38 plugs its decision logic in here.
+// as body content rather than as the start of a footer trailer.
+//
+// The decision is anchored on a single pre-scan (findTrailerBlockStart)
+// that is computed once per Parse() call and stored on the machine.
+// When the FSM is currently positioned strictly before that pre-scanned
+// trailer-block boundary, the upcoming line is body content (a
+// trailer-shaped paragraph head, a fake-trailer line in the middle of
+// a body paragraph, or trailing prose); otherwise it is — by
+// construction of the pre-scan — the start of the real trailer block
+// and the FSM should keep its historical behavior (enter trailerBeg).
+//
+// When the pre-scan found no trailer block at all (trailerBlockStart
+// is -1) the predicate returns false: there is nothing to redirect to,
+// trailerBeg can consume any trailing newlines on its own, and the
+// existing rewind action handles the case where the FSM mistakenly
+// ventured into trailerBeg with body content still ahead.
+//
+// The reason the predicate uses strict `<` (not `<=`) is that at
+// `m.p == m.trailerBlockStart - 1` the FSM is already sitting on the
+// final newline of the blank line that separates body from trailer; on
+// the next byte (m.p+1 == trailerBlockStart) the trailer-token first
+// character is the next thing the FSM will read. Letting trailerBeg
+// take over from that byte is exactly what we want.
 func (m *machine) shouldRedirectToBody() bool {
-	return false
+	// Find the position of the next non-newline byte starting from
+	// m.p+1. At every callsite of startTrailerParsing the FSM is
+	// positioned such that m.p still belongs to the current production
+	// (last byte of body consumed, or last byte of a footer value, or
+	// last byte of the description). The relevant question is: does
+	// the NEXT non-newline byte (start of the next line) live before
+	// the pre-scanned trailer block?
+	pos := m.p + 1
+	for pos < m.pe && m.data[pos] == '\n' {
+		pos++
+	}
+	if pos >= m.pe {
+		// Only newlines/EOF remain. Nothing for body to do; let the
+		// trailerBeg path absorb the trailing newlines on its own.
+		return false
+	}
+	if m.trailerBlockStart < 0 {
+		// Pre-scan found no trailing trailer block at all. The bytes
+		// ahead must be body content (or input the FSM later rejects
+		// as a malformed trailer; the existing rewind action handles
+		// that case by demoting back to body).
+		return true
+	}
+
+	// Redirect to body iff the next non-newline byte still lives
+	// strictly before the start of the pre-scanned trailer block. When
+	// pos == trailerBlockStart the FSM is positioned exactly on the
+	// trailer token's first byte and the historical trailerBeg path
+	// is what we want.
+	return pos < m.trailerBlockStart
 }
 
 func (m *machine) emitInfo(s string, args ...interface{}) {
@@ -145,6 +201,12 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 	m.err = nil
 	m.currentFooterKey = ""
 	m.countNewlines = 0
+	// Pre-compute the start offset of the trailing trailer block (or -1)
+	// once per Parse() call. The FSM consults this (via
+	// shouldRedirectToBody) to keep body parsing going past any
+	// trailer-shaped line that does not belong to the real trailer
+	// block. See issue #38.
+	m.trailerBlockStart = findTrailerBlockStart(input)
 	output := &conventionalCommit{}
 	output.footers = make(map[string][]string)
 	output.typeconfig = m.typeConfig
@@ -561,6 +623,13 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		// callsite stays one line of conditional + fgoto, so the generated
 		// machine.go does not multiply the predicate logic across callsites.
 		if m.shouldRedirectToBody() {
+			// Snap the marker forward so body's appendBody window starts
+			// fresh on the upcoming line instead of replaying any stale
+			// >mark from earlier productions (description, last footer val,
+			// etc.). m.p currently points at the newline that terminated
+			// the previous production, so m.p + 1 is the first byte of the
+			// line we are about to treat as body content.
+			m.pb = m.p + 1
 			m.emitDebug("redirecting to body parsing", "pos", m.p)
 			{
 				goto st34
@@ -599,6 +668,13 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		// callsite stays one line of conditional + fgoto, so the generated
 		// machine.go does not multiply the predicate logic across callsites.
 		if m.shouldRedirectToBody() {
+			// Snap the marker forward so body's appendBody window starts
+			// fresh on the upcoming line instead of replaying any stale
+			// >mark from earlier productions (description, last footer val,
+			// etc.). m.p currently points at the newline that terminated
+			// the previous production, so m.p + 1 is the first byte of the
+			// line we are about to treat as body content.
+			m.pb = m.p + 1
 			m.emitDebug("redirecting to body parsing", "pos", m.p)
 			{
 				goto st34
@@ -768,6 +844,13 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		// callsite stays one line of conditional + fgoto, so the generated
 		// machine.go does not multiply the predicate logic across callsites.
 		if m.shouldRedirectToBody() {
+			// Snap the marker forward so body's appendBody window starts
+			// fresh on the upcoming line instead of replaying any stale
+			// >mark from earlier productions (description, last footer val,
+			// etc.). m.p currently points at the newline that terminated
+			// the previous production, so m.p + 1 is the first byte of the
+			// line we are about to treat as body content.
+			m.pb = m.p + 1
 			m.emitDebug("redirecting to body parsing", "pos", m.p)
 			{
 				goto st34
@@ -910,6 +993,13 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		// callsite stays one line of conditional + fgoto, so the generated
 		// machine.go does not multiply the predicate logic across callsites.
 		if m.shouldRedirectToBody() {
+			// Snap the marker forward so body's appendBody window starts
+			// fresh on the upcoming line instead of replaying any stale
+			// >mark from earlier productions (description, last footer val,
+			// etc.). m.p currently points at the newline that terminated
+			// the previous production, so m.p + 1 is the first byte of the
+			// line we are about to treat as body content.
+			m.pb = m.p + 1
 			m.emitDebug("redirecting to body parsing", "pos", m.p)
 			{
 				goto st34
@@ -935,6 +1025,13 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		// callsite stays one line of conditional + fgoto, so the generated
 		// machine.go does not multiply the predicate logic across callsites.
 		if m.shouldRedirectToBody() {
+			// Snap the marker forward so body's appendBody window starts
+			// fresh on the upcoming line instead of replaying any stale
+			// >mark from earlier productions (description, last footer val,
+			// etc.). m.p currently points at the newline that terminated
+			// the previous production, so m.p + 1 is the first byte of the
+			// line we are about to treat as body content.
+			m.pb = m.p + 1
 			m.emitDebug("redirecting to body parsing", "pos", m.p)
 			{
 				goto st34
@@ -1201,6 +1298,13 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		// callsite stays one line of conditional + fgoto, so the generated
 		// machine.go does not multiply the predicate logic across callsites.
 		if m.shouldRedirectToBody() {
+			// Snap the marker forward so body's appendBody window starts
+			// fresh on the upcoming line instead of replaying any stale
+			// >mark from earlier productions (description, last footer val,
+			// etc.). m.p currently points at the newline that terminated
+			// the previous production, so m.p + 1 is the first byte of the
+			// line we are about to treat as body content.
+			m.pb = m.p + 1
 			m.emitDebug("redirecting to body parsing", "pos", m.p)
 			{
 				goto st34
@@ -1873,6 +1977,13 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		// callsite stays one line of conditional + fgoto, so the generated
 		// machine.go does not multiply the predicate logic across callsites.
 		if m.shouldRedirectToBody() {
+			// Snap the marker forward so body's appendBody window starts
+			// fresh on the upcoming line instead of replaying any stale
+			// >mark from earlier productions (description, last footer val,
+			// etc.). m.p currently points at the newline that terminated
+			// the previous production, so m.p + 1 is the first byte of the
+			// line we are about to treat as body content.
+			m.pb = m.p + 1
 			m.emitDebug("redirecting to body parsing", "pos", m.p)
 			{
 				goto st34
@@ -2458,6 +2569,13 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		// callsite stays one line of conditional + fgoto, so the generated
 		// machine.go does not multiply the predicate logic across callsites.
 		if m.shouldRedirectToBody() {
+			// Snap the marker forward so body's appendBody window starts
+			// fresh on the upcoming line instead of replaying any stale
+			// >mark from earlier productions (description, last footer val,
+			// etc.). m.p currently points at the newline that terminated
+			// the previous production, so m.p + 1 is the first byte of the
+			// line we are about to treat as body content.
+			m.pb = m.p + 1
 			m.emitDebug("redirecting to body parsing", "pos", m.p)
 			{
 				goto st34
@@ -3535,6 +3653,13 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 				// callsite stays one line of conditional + fgoto, so the generated
 				// machine.go does not multiply the predicate logic across callsites.
 				if m.shouldRedirectToBody() {
+					// Snap the marker forward so body's appendBody window starts
+					// fresh on the upcoming line instead of replaying any stale
+					// >mark from earlier productions (description, last footer val,
+					// etc.). m.p currently points at the newline that terminated
+					// the previous production, so m.p + 1 is the first byte of the
+					// line we are about to treat as body content.
+					m.pb = m.p + 1
 					m.emitDebug("redirecting to body parsing", "pos", m.p)
 					{
 						goto st34

--- a/parser/machine.go.rl
+++ b/parser/machine.go.rl
@@ -183,6 +183,16 @@ action append_body_before_blank_line {
 # Jumps
 
 action start_trailer_parsing {
+	// shouldRedirectToBody centralizes the decision of whether the next
+	// stretch of input should be parsed as body content rather than as
+	// the start of a footer trailer. Keeping the predicate in Go (and
+	// the fgoto in Ragel) means the action body Ragel emits at every
+	// callsite stays one line of conditional + fgoto, so the generated
+	// machine.go does not multiply the predicate logic across callsites.
+	if m.shouldRedirectToBody() {
+		m.emitDebug("redirecting to body parsing", "pos", m.p)
+		fgoto body;
+	}
 	m.emitDebug("try to parse a footer trailer token", "pos", m.p)
 	fgoto trailer_beg;
 }
@@ -318,6 +328,15 @@ type machine struct {
 
 func (m *machine) text() []byte {
 	return m.data[m.pb:m.p]
+}
+
+// shouldRedirectToBody is consulted by the start_trailer_parsing Ragel
+// action to decide whether the next stretch of input should be parsed
+// as body content rather than the start of a footer trailer. Returning
+// false preserves the historical behavior (always enter trailer
+// parsing). The fix for issue #38 plugs its decision logic in here.
+func (m *machine) shouldRedirectToBody() bool {
+	return false
 }
 
 func (m *machine) emitInfo(s string, args... interface{}) {

--- a/parser/machine.go.rl
+++ b/parser/machine.go.rl
@@ -508,6 +508,29 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 			// An error occurred but partial parsing is on and partial message is minimally valid
 			return output.export(), m.err
 		}
+		// Defensive: a few FSM error transitions (e.g. a trailing CR
+		// after an otherwise-complete trailer) leave m.cs < first_final
+		// without ever assigning m.err. Returning (nil, nil) at this
+		// point silently violates Parse's contract and nil-derefs the
+		// canonical caller pattern:
+		//
+		//   m, err := p.Parse(in)
+		//   if err != nil { return err }
+		//   if !m.Ok() { ... }            // <- NPE here on (nil, nil)
+		//
+		// Synthesize an early-exit error from the current cursor so
+		// strict-mode Parse always returns either a message or an
+		// error, never both nil. The cursor may be at EOF (m.p == m.pe)
+		// when this fires, so report against the previous byte when one
+		// exists and against an empty character otherwise. See PR #47
+		// second-pass review (§3) and TestParseNeverReturnsNilNil.
+		if m.err == nil {
+			if m.p > 0 && m.p-1 < len(m.data) {
+				m.err = m.emitErrorOnPreviousCharacter(ErrEarly)
+			} else {
+				m.err = m.emitError(ErrEarly, "", m.p)
+			}
+		}
 		return nil, m.err
 	}
 

--- a/parser/machine.go.rl
+++ b/parser/machine.go.rl
@@ -190,6 +190,13 @@ action start_trailer_parsing {
 	// callsite stays one line of conditional + fgoto, so the generated
 	// machine.go does not multiply the predicate logic across callsites.
 	if m.shouldRedirectToBody() {
+		// Snap the marker forward so body's append_body window starts
+		// fresh on the upcoming line instead of replaying any stale
+		// >mark from earlier productions (description, last footer val,
+		// etc.). m.p currently points at the newline that terminated
+		// the previous production, so m.p + 1 is the first byte of the
+		// line we are about to treat as body content.
+		m.pb = m.p + 1
 		m.emitDebug("redirecting to body parsing", "pos", m.p)
 		fgoto body;
 	}
@@ -324,6 +331,13 @@ type machine struct {
 	currentFooterKey string
 	countNewlines    int
 	lastNewline      int
+	// trailerBlockStart is the byte offset (within data) at which the
+	// trailing footer trailer block begins, or -1 when no such block
+	// exists. It is computed exactly once at the start of Parse() and
+	// is consulted by shouldRedirectToBody to decide whether a given
+	// >start_trailer_parsing entry should fall through to the body
+	// machine instead. See issue #38.
+	trailerBlockStart int
 }
 
 func (m *machine) text() []byte {
@@ -332,11 +346,60 @@ func (m *machine) text() []byte {
 
 // shouldRedirectToBody is consulted by the start_trailer_parsing Ragel
 // action to decide whether the next stretch of input should be parsed
-// as body content rather than the start of a footer trailer. Returning
-// false preserves the historical behavior (always enter trailer
-// parsing). The fix for issue #38 plugs its decision logic in here.
+// as body content rather than as the start of a footer trailer.
+//
+// The decision is anchored on a single pre-scan (findTrailerBlockStart)
+// that is computed once per Parse() call and stored on the machine.
+// When the FSM is currently positioned strictly before that pre-scanned
+// trailer-block boundary, the upcoming line is body content (a
+// trailer-shaped paragraph head, a fake-trailer line in the middle of
+// a body paragraph, or trailing prose); otherwise it is — by
+// construction of the pre-scan — the start of the real trailer block
+// and the FSM should keep its historical behavior (enter trailer_beg).
+//
+// When the pre-scan found no trailer block at all (trailerBlockStart
+// is -1) the predicate returns false: there is nothing to redirect to,
+// trailer_beg can consume any trailing newlines on its own, and the
+// existing rewind action handles the case where the FSM mistakenly
+// ventured into trailer_beg with body content still ahead.
+//
+// The reason the predicate uses strict `<` (not `<=`) is that at
+// `m.p == m.trailerBlockStart - 1` the FSM is already sitting on the
+// final newline of the blank line that separates body from trailer; on
+// the next byte (m.p+1 == trailerBlockStart) the trailer-token first
+// character is the next thing the FSM will read. Letting trailer_beg
+// take over from that byte is exactly what we want.
 func (m *machine) shouldRedirectToBody() bool {
-	return false
+	// Find the position of the next non-newline byte starting from
+	// m.p+1. At every callsite of start_trailer_parsing the FSM is
+	// positioned such that m.p still belongs to the current production
+	// (last byte of body consumed, or last byte of a footer value, or
+	// last byte of the description). The relevant question is: does
+	// the NEXT non-newline byte (start of the next line) live before
+	// the pre-scanned trailer block?
+	pos := m.p + 1
+	for pos < m.pe && m.data[pos] == '\n' {
+		pos++
+	}
+	if pos >= m.pe {
+		// Only newlines/EOF remain. Nothing for body to do; let the
+		// trailer_beg path absorb the trailing newlines on its own.
+		return false
+	}
+	if m.trailerBlockStart < 0 {
+		// Pre-scan found no trailing trailer block at all. The bytes
+		// ahead must be body content (or input the FSM later rejects
+		// as a malformed trailer; the existing rewind action handles
+		// that case by demoting back to body).
+		return true
+	}
+
+	// Redirect to body iff the next non-newline byte still lives
+	// strictly before the start of the pre-scanned trailer block. When
+	// pos == trailerBlockStart the FSM is positioned exactly on the
+	// trailer token's first byte and the historical trailer_beg path
+	// is what we want.
+	return pos < m.trailerBlockStart
 }
 
 func (m *machine) emitInfo(s string, args... interface{}) {
@@ -412,6 +475,12 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 	m.err = nil
 	m.currentFooterKey = ""
 	m.countNewlines = 0
+	// Pre-compute the start offset of the trailing trailer block (or -1)
+	// once per Parse() call. The FSM consults this (via
+	// shouldRedirectToBody) to keep body parsing going past any
+	// trailer-shaped line that does not belong to the real trailer
+	// block. See issue #38.
+	m.trailerBlockStart = findTrailerBlockStart(input)
 	output := &conventionalCommit{}
 	output.footers = make(map[string][]string)
 	output.typeconfig = m.typeConfig

--- a/parser/machine_test.go
+++ b/parser/machine_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMachineParse(t *testing.T) {
@@ -54,9 +55,13 @@ func runner(t *testing.T, label string, cases []testCase, machineOpts ...convent
 				assert.Equal(t, tc.partialValue, partial)
 				assert.EqualError(t, partialErr, tc.errorString)
 			} else {
-				// We expect the test case intput to be a valid commit message
+				// We expect the test case input to be a valid commit message.
+				// require.NotNil aborts the subtest cleanly so a regression
+				// surfaces as a clear test failure instead of a panic that
+				// crashes the test binary and hides every subsequent case.
 				assert.Nil(t, messageErr)
-				assert.NotEmpty(t, message)
+				require.NotNil(t, message, "expected a non-nil message for valid input %q", tc.input)
+				require.NotNil(t, partial, "expected a non-nil partial message for valid input %q", tc.input)
 				assert.True(t, message.Ok())
 				assert.Equal(t, message, partial)
 				assert.Equal(t, tc.partialValue, partial)

--- a/parser/perf_test.go
+++ b/parser/perf_test.go
@@ -4,11 +4,30 @@
 package parser
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/leodido/go-conventionalcommits"
 	cctesting "github.com/leodido/go-conventionalcommits/testing"
 )
+
+// makeFakeTrailerHeavyBody returns a body section composed of `paragraphs`
+// paragraphs, each ending in a trailer-shaped line that is NOT actually a
+// trailer (it lives mid-body). Used to exercise the issue #38 pre-scan
+// path under the worst realistic shape.
+func makeFakeTrailerHeavyBody(paragraphs int) string {
+	var b strings.Builder
+	for i := 0; i < paragraphs; i++ {
+		b.WriteString("paragraph prose line one for context\n")
+		b.WriteString("paragraph prose line two with detail\n")
+		b.WriteString("Looks-Like-Trailer: but-it-is-body\n")
+		if i != paragraphs-1 {
+			b.WriteString("\n")
+		}
+	}
+
+	return b.String()
+}
 
 // Avoid compiler optimizations that could remove the actual call we are benchmarking during benchmarks.
 var benchParseResult conventionalcommits.Message
@@ -95,6 +114,25 @@ Signed-off-by: Leonardo Di Donato <some@email.com>`),
 	{
 		label: "[no] missing whitespace in description",
 		input: []byte("feat(scope):a"),
+	},
+	// --- issue #38 pre-scan stress: bodies whose paragraphs end in
+	// trailer-shaped lines force the pre-scan to traverse many false
+	// candidates before locking onto the real trailer block.
+	{
+		label: "[ok] 10-fake-trailer-paragraphs then real trailer",
+		input: []byte("fix: x\n\n" + makeFakeTrailerHeavyBody(10) + "\n\nReviewed-by: X"),
+	},
+	{
+		label: "[ok] 100-fake-trailer-paragraphs then real trailer",
+		input: []byte("fix: x\n\n" + makeFakeTrailerHeavyBody(100) + "\n\nReviewed-by: X"),
+	},
+	{
+		label: "[ok] 10-fake-trailer-paragraphs no real trailer",
+		input: []byte("fix: x\n\n" + makeFakeTrailerHeavyBody(10)),
+	},
+	{
+		label: "[ok] 100-fake-trailer-paragraphs no real trailer",
+		input: []byte("fix: x\n\n" + makeFakeTrailerHeavyBody(100)),
 	},
 }
 

--- a/parser/testcases.go
+++ b/parser/testcases.go
@@ -957,6 +957,111 @@ Signed-off-by: Leonardo Di Donato <some@email.com>`),
 		"",
 		nil,
 	},
+	// --- Reproducers for issue #38 (trailer-looking lines abort parsing).
+	// See https://github.com/leodido/go-conventionalcommits/issues/38
+
+	// VALID / fake trailer at the start of body, followed by body prose.
+	{
+		"valid-fake-trailer-then-body-paragraph-issue38",
+		[]byte("feat: x\n\nFixes #15\n\nLorem ipsum dolor sit amet"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Body:        cctesting.StringAddress("Fixes #15\n\nLorem ipsum dolor sit amet"),
+			TypeConfig:  0,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Body:        cctesting.StringAddress("Fixes #15\n\nLorem ipsum dolor sit amet"),
+			TypeConfig:  0,
+		},
+		"",
+		nil,
+	},
+	// VALID / verbatim issue #38 input.
+	{
+		"valid-issue-38-verbatim",
+		[]byte("feat: some thing (hz/fl!144)\n\nFixes #15\n\nLorem ipsum dolor sit amet\n\nBREAKING CHANGE: Some explanation\nReviewed-by: XX <xx@example.com>"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "some thing (hz/fl!144)",
+			Body:        cctesting.StringAddress("Fixes #15\n\nLorem ipsum dolor sit amet"),
+			Footers: map[string][]string{
+				"breaking-change": {"Some explanation"},
+				"reviewed-by":     {"XX <xx@example.com>"},
+			},
+			TypeConfig: 0,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "some thing (hz/fl!144)",
+			Body:        cctesting.StringAddress("Fixes #15\n\nLorem ipsum dolor sit amet"),
+			Footers: map[string][]string{
+				"breaking-change": {"Some explanation"},
+				"reviewed-by":     {"XX <xx@example.com>"},
+			},
+			TypeConfig: 0,
+		},
+		"",
+		nil,
+	},
+	// VALID / body paragraph whose LAST line is trailer-shaped, followed
+	// by a real trailer block. Must not regress.
+	{
+		"valid-body-ending-trailer-shape-then-real-trailer",
+		[]byte("feat: x\n\nbody1\nFake: trail\n\nReviewed-by: X"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Body:        cctesting.StringAddress("body1\nFake: trail"),
+			Footers: map[string][]string{
+				"reviewed-by": {"X"},
+			},
+			TypeConfig: 0,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Body:        cctesting.StringAddress("body1\nFake: trail"),
+			Footers: map[string][]string{
+				"reviewed-by": {"X"},
+			},
+			TypeConfig: 0,
+		},
+		"",
+		nil,
+	},
+	// VALID / two body paragraphs each ending in a trailer-shaped line,
+	// followed by a real trailer block. Must not regress.
+	{
+		"valid-multi-paragraph-body-each-ending-trailer-shape-then-real-trailer",
+		[]byte("feat: x\n\npara1\nFake: a\n\npara2\nFake: b\n\nReviewed-by: X"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Body:        cctesting.StringAddress("para1\nFake: a\n\npara2\nFake: b"),
+			Footers: map[string][]string{
+				"reviewed-by": {"X"},
+			},
+			TypeConfig: 0,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Body:        cctesting.StringAddress("para1\nFake: a\n\npara2\nFake: b"),
+			Footers: map[string][]string{
+				"reviewed-by": {"X"},
+			},
+			TypeConfig: 0,
+		},
+		"",
+		nil,
+	},
 }
 
 var testCasesForFalcoTypes = []testCase{
@@ -2580,6 +2685,111 @@ see the issue for details.`),
 			Type:        "fix",
 			Description: "correct something",
 			TypeConfig:  1,
+		},
+		"",
+		nil,
+	},
+	// --- Reproducers for issue #38 (trailer-looking lines abort parsing).
+	// See https://github.com/leodido/go-conventionalcommits/issues/38
+
+	// VALID / fake trailer at the start of body, followed by body prose.
+	{
+		"valid-fake-trailer-then-body-paragraph-issue38",
+		[]byte("feat: x\n\nFixes #15\n\nLorem ipsum dolor sit amet"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Body:        cctesting.StringAddress("Fixes #15\n\nLorem ipsum dolor sit amet"),
+			TypeConfig:  1,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Body:        cctesting.StringAddress("Fixes #15\n\nLorem ipsum dolor sit amet"),
+			TypeConfig:  1,
+		},
+		"",
+		nil,
+	},
+	// VALID / verbatim issue #38 input.
+	{
+		"valid-issue-38-verbatim",
+		[]byte("feat: some thing (hz/fl!144)\n\nFixes #15\n\nLorem ipsum dolor sit amet\n\nBREAKING CHANGE: Some explanation\nReviewed-by: XX <xx@example.com>"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "some thing (hz/fl!144)",
+			Body:        cctesting.StringAddress("Fixes #15\n\nLorem ipsum dolor sit amet"),
+			Footers: map[string][]string{
+				"breaking-change": {"Some explanation"},
+				"reviewed-by":     {"XX <xx@example.com>"},
+			},
+			TypeConfig: 1,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "some thing (hz/fl!144)",
+			Body:        cctesting.StringAddress("Fixes #15\n\nLorem ipsum dolor sit amet"),
+			Footers: map[string][]string{
+				"breaking-change": {"Some explanation"},
+				"reviewed-by":     {"XX <xx@example.com>"},
+			},
+			TypeConfig: 1,
+		},
+		"",
+		nil,
+	},
+	// VALID / body paragraph whose LAST line is trailer-shaped, followed
+	// by a real trailer block. Must not regress.
+	{
+		"valid-body-ending-trailer-shape-then-real-trailer",
+		[]byte("feat: x\n\nbody1\nFake: trail\n\nReviewed-by: X"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Body:        cctesting.StringAddress("body1\nFake: trail"),
+			Footers: map[string][]string{
+				"reviewed-by": {"X"},
+			},
+			TypeConfig: 1,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Body:        cctesting.StringAddress("body1\nFake: trail"),
+			Footers: map[string][]string{
+				"reviewed-by": {"X"},
+			},
+			TypeConfig: 1,
+		},
+		"",
+		nil,
+	},
+	// VALID / two body paragraphs each ending in a trailer-shaped line,
+	// followed by a real trailer block. Must not regress.
+	{
+		"valid-multi-paragraph-body-each-ending-trailer-shape-then-real-trailer",
+		[]byte("feat: x\n\npara1\nFake: a\n\npara2\nFake: b\n\nReviewed-by: X"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Body:        cctesting.StringAddress("para1\nFake: a\n\npara2\nFake: b"),
+			Footers: map[string][]string{
+				"reviewed-by": {"X"},
+			},
+			TypeConfig: 1,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Body:        cctesting.StringAddress("para1\nFake: a\n\npara2\nFake: b"),
+			Footers: map[string][]string{
+				"reviewed-by": {"X"},
+			},
+			TypeConfig: 1,
 		},
 		"",
 		nil,

--- a/parser/testcases.go
+++ b/parser/testcases.go
@@ -1062,6 +1062,38 @@ Signed-off-by: Leonardo Di Donato <some@email.com>`),
 		"",
 		nil,
 	},
+	// VALID / minimised: body's last line is itself trailer-shaped
+	// (`Refs: 123`) and is followed by a blank line and a real trailer
+	// (`Reviewed-by: X`). The pre-scan must commit the trailer block
+	// at the gap above `Reviewed-by:` rather than extending the
+	// candidate run upward across the `Refs: 123` continuation. Catches
+	// the second-pass review's §2 shape (body1\nRefs: 123 / Reviewed-by:)
+	// which lives between the two cases above and would otherwise drift.
+	{
+		"valid-body-ending-trailer-shape-refs-then-real-trailer",
+		[]byte("fix: x\n\nbody1\nRefs: 123\n\nReviewed-by: X"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "x",
+			Body:        cctesting.StringAddress("body1\nRefs: 123"),
+			Footers: map[string][]string{
+				"reviewed-by": {"X"},
+			},
+			TypeConfig: 0,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "x",
+			Body:        cctesting.StringAddress("body1\nRefs: 123"),
+			Footers: map[string][]string{
+				"reviewed-by": {"X"},
+			},
+			TypeConfig: 0,
+		},
+		"",
+		nil,
+	},
 }
 
 var testCasesForFalcoTypes = []testCase{
@@ -2786,6 +2818,38 @@ see the issue for details.`),
 			Type:        "feat",
 			Description: "x",
 			Body:        cctesting.StringAddress("para1\nFake: a\n\npara2\nFake: b"),
+			Footers: map[string][]string{
+				"reviewed-by": {"X"},
+			},
+			TypeConfig: 1,
+		},
+		"",
+		nil,
+	},
+	// VALID / minimised: body's last line is itself trailer-shaped
+	// (`Refs: 123`) and is followed by a blank line and a real trailer
+	// (`Reviewed-by: X`). The pre-scan must commit the trailer block
+	// at the gap above `Reviewed-by:` rather than extending the
+	// candidate run upward across the `Refs: 123` continuation. Catches
+	// the second-pass review's §2 shape (body1\nRefs: 123 / Reviewed-by:)
+	// which lives between the two cases above and would otherwise drift.
+	{
+		"valid-body-ending-trailer-shape-refs-then-real-trailer",
+		[]byte("fix: x\n\nbody1\nRefs: 123\n\nReviewed-by: X"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "x",
+			Body:        cctesting.StringAddress("body1\nRefs: 123"),
+			Footers: map[string][]string{
+				"reviewed-by": {"X"},
+			},
+			TypeConfig: 1,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "x",
+			Body:        cctesting.StringAddress("body1\nRefs: 123"),
 			Footers: map[string][]string{
 				"reviewed-by": {"X"},
 			},

--- a/parser/trailer_scan.go
+++ b/parser/trailer_scan.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2020- Leonardo Di Donato <leodidonato@gmail.com>
+package parser
+
+import (
+	"bytes"
+)
+
+// findTrailerBlockStart returns the byte offset, within data, at which
+// the trailing footer trailer block begins, or -1 if no such block is
+// present.
+//
+// The "trailer block" is the longest run of trailer-shaped sections at
+// the end of the message. A "section" is one trailer-shaped first line
+// followed by zero or more continuation lines. Sections inside the
+// block may be separated from each other by one or more blank lines —
+// this matches the FSM's `trailer_beg = nl* trailer_init` semantics,
+// where arbitrary blank-line gaps between trailer sub-blocks are
+// tolerated. The block ends (going up) at the first blank-line gap
+// whose line above is NOT trailer-shaped: that line above is body
+// content, and the blank line is the body/trailer separator.
+//
+// Trailer-shaped, per `trailer_init` in machine.go.rl, means:
+//
+//   - `alnum+ (- alnum+)*` then either `: <ws>+` (single-space `ws`,
+//     per `common.rl`) or ` #<value>`; or
+//   - the special-case `BREAKING CHANGE: <ws>+`.
+//
+// Returning a nonzero offset does NOT assert that every line in the
+// block is well-formed: the FSM is responsible for rejecting malformed
+// trailer values via its existing rewind/error paths once it enters
+// trailer parsing.
+//
+// The first line of the message (offset 0) is the description and is
+// never part of a trailer block, even when its text looks trailer-
+// shaped.
+//
+// Trailing newlines/whitespace at the end of the input are ignored
+// when locating the block.
+func findTrailerBlockStart(data []byte) int {
+	if len(data) == 0 {
+		return -1
+	}
+
+	// Drop trailing newlines so they don't get mis-attributed.
+	end := len(data)
+	for end > 0 && data[end-1] == '\n' {
+		end--
+	}
+	if end == 0 {
+		return -1
+	}
+
+	// Walk bottom-up across blank-line gaps. A gap may extend the
+	// trailer block iff the line above the gap is itself trailer-
+	// shaped. Otherwise the gap is the body/trailer separator and the
+	// block (if any) starts at the first trailer-shaped line below the
+	// gap.
+	//
+	// To enter the loop with a candidate block, the first trailer-
+	// shaped line above the bottom-most blank-line gap must exist and
+	// must NOT be the description line.
+	candidate := -1
+	gapEnd := end
+	for {
+		// Find the previous `\n\n` (blank-line separator) inside
+		// data[:gapEnd]. The line that starts immediately after the
+		// `\n\n` is the candidate first line of a (possibly extended)
+		// trailer block.
+		idx := bytes.LastIndex(data[:gapEnd], []byte("\n\n"))
+		if idx < 0 {
+			// No blank-line separator above; whatever we have so far
+			// is the answer.
+			return candidate
+		}
+		// Skip extra newlines: a run of three or more newlines is one
+		// gap. The first line after the run starts at `lineStart`.
+		lineStart := idx + 2
+		for lineStart < end && data[lineStart] == '\n' {
+			lineStart++
+		}
+		if lineStart >= end {
+			// All newlines up to EOF; nothing classifiable.
+			return candidate
+		}
+		if lineStart == 0 {
+			// Would start at the description line.
+			return candidate
+		}
+		if !isTrailerStartLine(lineAt(data, lineStart, end)) {
+			// First line after the gap isn't trailer-shaped: this gap
+			// terminates the block at the previous candidate.
+			return candidate
+		}
+		// This gap is inside a trailer block: extend the block up to
+		// `lineStart` and look for an even earlier gap.
+		candidate = lineStart
+		gapEnd = idx
+	}
+}
+
+// lineAt returns the slice of data starting at start and ending at the
+// next newline (exclusive) or at end (exclusive), whichever comes first.
+func lineAt(data []byte, start, end int) []byte {
+	stop := bytes.IndexByte(data[start:end], '\n')
+	if stop < 0 {
+		return data[start:end]
+	}
+
+	return data[start : start+stop]
+}
+
+// isTrailerStartLine reports whether line begins a trailer (token plus
+// separator), matching `trailer_init` in machine.go.rl. The whitespace
+// alphabet is a single ASCII space, matching `ws = ' '` in common.rl.
+//
+// Grammar:
+//
+//	trailer_tok = alnum+ (- alnum+)*
+//	trailer_sep = (':' ws+) | (ws '#')
+//	trailer_init = ('BREAKING CHANGE' >mark trailer_sep_breaking)
+//	             | (trailer_tok >mark trailer_sep)
+//	trailer_sep_breaking = ':' ws+
+//
+// Returning true does NOT mean the rest of the line is a valid trailer
+// value; the FSM catches malformed values at parse time. The pre-scan
+// only needs to confirm the line OPENS like a trailer.
+func isTrailerStartLine(line []byte) bool {
+	if bytes.HasPrefix(line, []byte("BREAKING CHANGE")) {
+		rest := line[len("BREAKING CHANGE"):]
+		// trailer_sep_breaking := colon ws+
+		if len(rest) >= 2 && rest[0] == ':' && rest[1] == ' ' {
+			return true
+		}
+
+		return false
+	}
+
+	// trailer_tok := alnum+ (dash alnum+)*
+	i := 0
+	if i >= len(line) || !isAlnum(line[i]) {
+		return false
+	}
+	for i < len(line) && isAlnum(line[i]) {
+		i++
+	}
+	for i < len(line) && line[i] == '-' {
+		i++
+		if i >= len(line) || !isAlnum(line[i]) {
+			return false
+		}
+		for i < len(line) && isAlnum(line[i]) {
+			i++
+		}
+	}
+	if i >= len(line) {
+		return false
+	}
+	// trailer_sep := (colon ws+) | (ws '#')
+	switch line[i] {
+	case ':':
+		i++
+		if i >= len(line) || line[i] != ' ' {
+			return false
+		}
+
+		return true
+	case ' ':
+		i++
+		if i >= len(line) || line[i] != '#' {
+			return false
+		}
+
+		return true
+	}
+
+	return false
+}
+
+// isAlnum mirrors Ragel's ASCII-only `alnum` class (digits + ASCII
+// letters). If the FSM grammar ever broadens to accept Unicode letters
+// this needs to track that change to keep the pre-scan and the FSM in
+// agreement.
+func isAlnum(b byte) bool {
+	return (b >= '0' && b <= '9') || (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z')
+}

--- a/parser/trailer_scan.go
+++ b/parser/trailer_scan.go
@@ -38,6 +38,13 @@ import (
 //
 // Trailing newlines/whitespace at the end of the input are ignored
 // when locating the block.
+//
+// Performance: the implementation is one forward pass over data to
+// build the per-line offset table, plus one reverse pass over that
+// table that does at most one isTrailerStartLine check per blank-line
+// gap. Both passes are O(n) where n = len(data); no quadratic
+// LastIndex behavior, even on inputs with many trailer-shaped
+// paragraphs.
 func findTrailerBlockStart(data []byte) int {
 	if len(data) == 0 {
 		return -1
@@ -52,52 +59,82 @@ func findTrailerBlockStart(data []byte) int {
 		return -1
 	}
 
-	// Walk bottom-up across blank-line gaps. A gap may extend the
-	// trailer block iff the line above the gap is itself trailer-
-	// shaped. Otherwise the gap is the body/trailer separator and the
-	// block (if any) starts at the first trailer-shaped line below the
-	// gap.
-	//
-	// To enter the loop with a candidate block, the first trailer-
-	// shaped line above the bottom-most blank-line gap must exist and
-	// must NOT be the description line.
-	candidate := -1
-	gapEnd := end
-	for {
-		// Find the previous `\n\n` (blank-line separator) inside
-		// data[:gapEnd]. The line that starts immediately after the
-		// `\n\n` is the candidate first line of a (possibly extended)
-		// trailer block.
-		idx := bytes.LastIndex(data[:gapEnd], []byte("\n\n"))
-		if idx < 0 {
-			// No blank-line separator above; whatever we have so far
-			// is the answer.
-			return candidate
-		}
-		// Skip extra newlines: a run of three or more newlines is one
-		// gap. The first line after the run starts at `lineStart`.
-		lineStart := idx + 2
-		for lineStart < end && data[lineStart] == '\n' {
-			lineStart++
-		}
-		if lineStart >= end {
-			// All newlines up to EOF; nothing classifiable.
-			return candidate
-		}
-		if lineStart == 0 {
-			// Would start at the description line.
-			return candidate
-		}
-		if !isTrailerStartLine(lineAt(data, lineStart, end)) {
-			// First line after the gap isn't trailer-shaped: this gap
-			// terminates the block at the previous candidate.
-			return candidate
-		}
-		// This gap is inside a trailer block: extend the block up to
-		// `lineStart` and look for an even earlier gap.
-		candidate = lineStart
-		gapEnd = idx
+	// Forward pass: record the byte offset of the first byte of every
+	// non-blank line in data[:end] and whether that line is preceded
+	// by a blank-line gap. The first line (i == 0) is the description,
+	// blankBefore[0] is always false by convention.
+	lineStart, blankBefore := scanLines(data, end)
+	if len(lineStart) == 0 {
+		return -1
 	}
+
+	// Reverse pass: walk lines from the bottom up. Each blank-line gap
+	// either extends the trailer block (when the line right after the
+	// gap, i.e. the line at lineStart[i], is trailer-shaped) or
+	// terminates it. Continuation lines (no blank gap above them) are
+	// part of whatever block the line above them belongs to, so we
+	// don't classify them.
+	candidate := -1
+	for i := len(lineStart) - 1; i >= 0; i-- {
+		if !blankBefore[i] {
+			continue
+		}
+		if i == 0 {
+			// Would extend up to the description line; never classify
+			// the description as part of the trailer block.
+			return candidate
+		}
+		if !isTrailerStartLine(lineAt(data, lineStart[i], end)) {
+			// The line at lineStart[i] is not trailer-shaped. The
+			// previous candidate (set at a deeper line) is the answer.
+			return candidate
+		}
+		// Trailer-shaped first line of a sub-block: extend the block
+		// up to here and look for an even deeper gap.
+		candidate = lineStart[i]
+	}
+
+	return candidate
+}
+
+// scanLines walks data[:end] once and returns:
+//   - lineStart: the byte offset (within data) of the first byte of
+//     each non-blank line, in order;
+//   - blankBefore: a parallel slice where blankBefore[i] is true iff
+//     the line starting at lineStart[i] is preceded by at least one
+//     blank-line gap (i.e., a run of two or more consecutive newlines).
+//
+// blankBefore[0] is always false (the description has nothing before
+// it).
+func scanLines(data []byte, end int) ([]int, []bool) {
+	// A typical Conventional Commit has between 1 and ~30 lines; pre-
+	// allocating a small backing array avoids the first few growths
+	// without overshooting on small inputs.
+	lineStart := make([]int, 0, 16)
+	blankBefore := make([]bool, 0, 16)
+
+	pos := 0
+	consecutiveNL := 0
+	atLineStart := true
+	for pos < end {
+		b := data[pos]
+		if b == '\n' {
+			consecutiveNL++
+			atLineStart = true
+			pos++
+
+			continue
+		}
+		if atLineStart {
+			lineStart = append(lineStart, pos)
+			blankBefore = append(blankBefore, pos != 0 && consecutiveNL >= 2)
+			atLineStart = false
+			consecutiveNL = 0
+		}
+		pos++
+	}
+
+	return lineStart, blankBefore
 }
 
 // lineAt returns the slice of data starting at start and ending at the

--- a/parser/trailer_scan_test.go
+++ b/parser/trailer_scan_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2020- Leonardo Di Donato <leodidonato@gmail.com>
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindTrailerBlockStart(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{
+			name:  "empty",
+			input: "",
+			want:  -1,
+		},
+		{
+			name:  "trailing-newlines-only",
+			input: "\n\n\n",
+			want:  -1,
+		},
+		{
+			name:  "description-only",
+			input: "fix: x",
+			want:  -1,
+		},
+		{
+			name:  "description-then-trailing-newlines",
+			input: "fix: x\n\n",
+			want:  -1,
+		},
+		{
+			name:  "single-trailer",
+			input: "fix: x\n\nFixes: 3",
+			want:  len("fix: x\n\n"),
+		},
+		{
+			name:  "multiple-trailers-no-blank-gap",
+			input: "fix: x\n\nFixes #3\nSigned-off-by: Leo",
+			want:  len("fix: x\n\n"),
+		},
+		{
+			name:  "trailer-block-with-internal-blank-gap",
+			input: "fix: x\n\nAcked-by: Leo\n\nBREAKING CHANGE: APIs",
+			want:  len("fix: x\n\n"),
+		},
+		{
+			name:  "trailer-block-after-many-blank-lines",
+			input: "fix: x\n\n\n\n\nFixes #3\nSigned-off-by: Leo",
+			want:  len("fix: x\n\n\n\n\n"),
+		},
+		{
+			name:  "fake-trailer-then-body-paragraph",
+			input: "feat: x\n\nFixes #15\n\nLorem ipsum dolor sit amet",
+			want:  -1,
+		},
+		{
+			name:  "body-line-ending-trailer-shape-then-real-trailer",
+			input: "feat: x\n\nbody1\nFake: trail\n\nReviewed-by: X",
+			want:  len("feat: x\n\nbody1\nFake: trail\n\n"),
+		},
+		{
+			name:  "multi-paragraph-body-each-ending-trailer-shape-then-real-trailer",
+			input: "feat: x\n\npara1\nFake: a\n\npara2\nFake: b\n\nReviewed-by: X",
+			want:  len("feat: x\n\npara1\nFake: a\n\npara2\nFake: b\n\n"),
+		},
+		{
+			name:  "malformed-trailer-line-inside-block",
+			input: "fix: x\n\nTested-by: Leo\nX-\nAnother-trailer: x",
+			want:  len("fix: x\n\n"),
+		},
+		{
+			name:  "trailer-block-with-trailing-newline",
+			input: "fix: x\n\nFixes: 3\n",
+			want:  len("fix: x\n\n"),
+		},
+		{
+			name:  "breaking-change-special-case",
+			input: "fix: x\n\nBREAKING CHANGE: APIs",
+			want:  len("fix: x\n\n"),
+		},
+		{
+			name:  "breaking-change-without-space-after-colon",
+			input: "fix: x\n\nBREAKING CHANGE:APIs",
+			want:  -1,
+		},
+		{
+			name:  "trailer-with-hash-token",
+			input: "fix: x\n\nCloses #42",
+			want:  len("fix: x\n\n"),
+		},
+		{
+			name: "trailer-with-tab-after-colon-not-trailer-shaped",
+			// `ws` in common.rl is a single ASCII space, so a tab
+			// after the colon disqualifies the line; this also
+			// mirrors the FSM's behavior on develop.
+			input: "fix: x\n\nFixes:\t3",
+			want:  -1,
+		},
+		{
+			name: "first-line-trailer-shaped-no-blank-line-no-trailer-block",
+			// No blank line means no separator means no trailer block.
+			input: "Fixes: 3",
+			want:  -1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := findTrailerBlockStart([]byte(tc.input))
+			assert.Equal(t, tc.want, got, "input=%q", tc.input)
+		})
+	}
+}
+
+func TestIsTrailerStartLine(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{"empty", "", false},
+		{"plain-token-then-colon-space", "Fixes: 3", true},
+		{"plain-token-then-colon-no-space", "Fixes:3", false},
+		{"plain-token-then-colon-tab", "Fixes:\t3", false},
+		{"plain-token-then-space-hash", "Closes #3", true},
+		{"plain-token-then-space-no-hash", "Closes 3", false},
+		{"hyphenated-token", "Signed-off-by: Leo", true},
+		{"hyphenated-token-trailing-dash", "X-: foo", false},
+		{"hyphenated-token-leading-dash", "-X: foo", false},
+		{"breaking-change-with-space", "BREAKING CHANGE: APIs", true},
+		{"breaking-change-no-space", "BREAKING CHANGE:APIs", false},
+		{"breaking-change-prefix-different-case", "breaking change: APIs", false},
+		{"non-alnum-start", " Fixes: 3", false},
+		{"alnum-only-no-sep", "Fixes", false},
+		{"underscore-not-alnum-by-ragel", "snake_case: x", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isTrailerStartLine([]byte(tc.line))
+			assert.Equal(t, tc.want, got, "line=%q", tc.line)
+		})
+	}
+}
+
+func TestFindTrailerBlockStartLargeInput(t *testing.T) {
+	// Sanity check: the implementation should be linear-time. We don't
+	// time-bound the test (CI noise would flake it) but we DO want to
+	// exercise the perf path with a many-paragraph body so any
+	// quadratic regression shows up loud in benchmarks.
+	var b strings.Builder
+	b.WriteString("feat: x\n\n")
+	for i := 0; i < 1000; i++ {
+		b.WriteString("paragraph line one\n")
+		b.WriteString("paragraph line two: looks-like-trailer\n")
+		b.WriteString("\n")
+	}
+	b.WriteString("Reviewed-by: X")
+
+	idx := findTrailerBlockStart([]byte(b.String()))
+	assert.Equal(t, len(b.String())-len("Reviewed-by: X"), idx)
+}


### PR DESCRIPTION
Fixes #38.

## Problem

The FSM aborted parsing — or, in best-effort mode, silently truncated the
result — whenever a commit-message body contained a line that *looked like*
a git trailer but was followed by additional body content. Footer detection
was greedy: the first trailer-shaped line right after the description's
blank line was committed as a footer, and the existing `rewind` action
could not demote it back to body once any footer had been recorded.

The verbatim example from the issue:

```text
feat: some thing (hz/fl!144)

Fixes #15

Lorem ipsum dolor sit amet

BREAKING CHANGE: Some explanation
Reviewed-by: XX <xx@example.com>
```

…returned `nil, "illegal 'i' character in trailer: col=47"` and lost both
real trailers.

## Approach

A bottom-up Go pre-scan (`parser/trailer_scan.go`) locates the byte offset
where the trailing trailer block begins, or returns `-1`. The result is
computed once per `Parse` call and stored on the machine struct
(`m.trailerBlockStart`). The Ragel FSM consults this field at exactly two
decision points:

- **`start_trailer_parsing`** — if a trailer block was located further down
  (or none exists and there is still non-whitespace ahead), route through
  `body` first instead of greedily entering `trailer_beg`. Snapping `m.pb`
  to `m.p+1` keeps the first `append_body` window clean.
- **`blank_line_ahead`** — true for the blank line that precedes the
  pre-scanned trailer block, and also for trailing whitespace at EOF when
  no block exists at all (so body parsing trims trailing newlines instead
  of consuming them).

The pre-scan grammar mirrors `trailer_init` exactly to avoid drift:
`alnum+ (-alnum+)*` then `: <ws>` or ` #`, plus the `BREAKING CHANGE: <ws>`
special case. Inner blank-line gaps inside the trailer block are tolerated
only when both sides are trailer-shaped (matches the FSM's
`nl* (trailer_init)?` semantics). Line 0 (the description) is never part
of a trailer block, even when its text is shaped like one.

Spec alignment: clauses 6 (body after blank line), 7 (multi-paragraph body),
8 (trailers in trailing block separated by blank line).

## Commits

1. `test:` — 22 table-driven reproducers across `testCases` /
   `testCasesForConventionalTypes` plus `Example_fake_trailer` in the
   godocs. All red after this commit.
2. `fix(parser):` — pre-scan + FSM hook + regenerated `parser/machine.go`.
   All reproducers green; full existing suite green.

## Backwards compatibility

The seven `invalid-…-after-trailers` and `valid-with-multi-line-body-…`
tests originally flagged as "may need updating" all continue to pass with
the chosen approach — no expectation changes were required.

The `R3.1` reproducer (multi-line trailer continuation per spec clause 10)
was dropped from the test set: continuation values are a separate FSM
grammar change, out of scope for #38, and tracked separately.

## Performance

`make bench` (Intel Xeon Platinum 8375C, `-benchtime=2s`):

```
geomean   527.6n → 558.5n   +5.87%
```

All individual cases regress by less than 15%; well within the ~10%
geomean budget set up front. No new allocations on the hot paths that
matter (minimal/scope/breaking parses).

## Tests

`go test ./...` — green (no skips).
`go vet ./...` — only the pre-existing Ragel-generated `unreachable code`
warnings, identical count to `develop`.
