### PR TITLE
feat(parser): support multi-line trailer values per spec clause 10

### DIFF
--- a/parser/machine.go
+++ b/parser/machine.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"bytes"
 	"fmt"
+	"sort"
 
 	"github.com/leodido/go-conventionalcommits"
 	"github.com/sirupsen/logrus"
@@ -147,38 +148,39 @@ func (m *machine) shouldRedirectToBody() bool {
 // value should continue past the newline at m.p (clause-10
 // termination predicate).
 //
-// The newline is consumed iff:
+// At call time m.p is the index of the '\n' under consideration for
+// consumption into the value (data[m.p] == '\n'). The newline is
+// consumed iff ALL of:
+//   - there is at least one byte after it (else we are at EOF and
+//     there is nothing to continue into);
+//   - the byte right after it is NOT itself '\n' (a '\n' immediately
+//     after this one means data[m.p:m.p+2] is the blank-line gap that
+//     terminates the trailer block per the standard FSM contract);
 //   - the byte right after it is NOT the start of a real trailer line
 //     per the pre-scan (otherwise the next line is the next trailer
-//     and the value must terminate here), AND
-//   - the next byte pair is not the start of a blank-line gap
-//     (a blank line terminates the trailer block per the standard
-//     FSM contract; nothing about clause-10 changes that).
+//     and the value must terminate here per spec clause 10).
 //
-// The first condition is the new clause-10 behavior. The second
-// condition preserves pre-existing semantics. See issue #48.
+// See issue #48 and the §B.2 finding in PR #49's third-pass review:
+// previously the blank-line check looked at data[m.p+1] and
+// data[m.p+2], which is "is there a blank-line gap STARTING at the
+// next byte" — wrong question. The right question is "is the current
+// byte the FIRST half of a blank-line gap", i.e. data[m.p+1] == '\n'.
 func (m *machine) trailerValueContinues() bool {
 	// Reject if we're at or past EOF: nothing to continue into.
 	if m.p+1 >= m.pe {
 		return false
 	}
-	// Reject if a blank line follows: the trailer block ends there.
-	if m.p+2 < m.pe && m.data[m.p+1] == '\n' && m.data[m.p+2] == '\n' {
+	// Reject if the next byte is also '\n': data[m.p:m.p+2] is the
+	// blank-line gap that terminates the trailer block.
+	if m.data[m.p+1] == '\n' {
 		return false
 	}
 	// Reject if the next line is itself a real trailer line per the
-	// pre-scan. Binary search keeps this O(log n) per call.
+	// pre-scan. sort.SearchInts is the same O(log n) binary search,
+	// just shorter to read than the hand-rolled loop.
 	next := m.p + 1
-	lo, hi := 0, len(m.trailerLineStarts)
-	for lo < hi {
-		mid := int(uint(lo+hi) >> 1)
-		if m.trailerLineStarts[mid] < next {
-			lo = mid + 1
-		} else {
-			hi = mid
-		}
-	}
-	if lo < len(m.trailerLineStarts) && m.trailerLineStarts[lo] == next {
+	i := sort.SearchInts(m.trailerLineStarts, next)
+	if i < len(m.trailerLineStarts) && m.trailerLineStarts[i] == next {
 		return false
 	}
 

--- a/parser/machine.go
+++ b/parser/machine.go
@@ -70,6 +70,14 @@ type machine struct {
 	// >startTrailerParsing entry should fall through to the body
 	// machine instead. See issue #38.
 	trailerBlockStart int
+	// trailerLineStarts is the sorted list of byte offsets within data
+	// at which a real trailer line begins (the first line of the block
+	// plus every continuation that is itself trailerInit-shaped).
+	// Empty when no trailer block is present. It is consulted by
+	// trailerValueContinues to enforce spec clause-10 termination of
+	// multi-line trailer values: a value continues across a newline
+	// iff the next line is NOT registered here. See issue #48.
+	trailerLineStarts []int
 }
 
 func (m *machine) text() []byte {
@@ -132,6 +140,49 @@ func (m *machine) shouldRedirectToBody() bool {
 	// trailer token's first byte and the historical trailerBeg path
 	// is what we want.
 	return pos < m.trailerBlockStart
+}
+
+// trailerValueContinues is consulted by the trailerVal Ragel
+// production to decide whether the in-progress multi-line trailer
+// value should continue past the newline at m.p (clause-10
+// termination predicate).
+//
+// The newline is consumed iff:
+//   - the byte right after it is NOT the start of a real trailer line
+//     per the pre-scan (otherwise the next line is the next trailer
+//     and the value must terminate here), AND
+//   - the next byte pair is not the start of a blank-line gap
+//     (a blank line terminates the trailer block per the standard
+//     FSM contract; nothing about clause-10 changes that).
+//
+// The first condition is the new clause-10 behavior. The second
+// condition preserves pre-existing semantics. See issue #48.
+func (m *machine) trailerValueContinues() bool {
+	// Reject if we're at or past EOF: nothing to continue into.
+	if m.p+1 >= m.pe {
+		return false
+	}
+	// Reject if a blank line follows: the trailer block ends there.
+	if m.p+2 < m.pe && m.data[m.p+1] == '\n' && m.data[m.p+2] == '\n' {
+		return false
+	}
+	// Reject if the next line is itself a real trailer line per the
+	// pre-scan. Binary search keeps this O(log n) per call.
+	next := m.p + 1
+	lo, hi := 0, len(m.trailerLineStarts)
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if m.trailerLineStarts[mid] < next {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	if lo < len(m.trailerLineStarts) && m.trailerLineStarts[lo] == next {
+		return false
+	}
+
+	return true
 }
 
 func (m *machine) emitInfo(s string, args ...interface{}) {
@@ -202,11 +253,14 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 	m.currentFooterKey = ""
 	m.countNewlines = 0
 	// Pre-compute the start offset of the trailing trailer block (or -1)
-	// once per Parse() call. The FSM consults this (via
-	// shouldRedirectToBody) to keep body parsing going past any
+	// AND the sorted offsets of every real-trailer line within that
+	// block, once per Parse() call. The FSM consults trailerBlockStart
+	// (via shouldRedirectToBody) to keep body parsing going past any
 	// trailer-shaped line that does not belong to the real trailer
-	// block. See issue #38.
-	m.trailerBlockStart = findTrailerBlockStart(input)
+	// block (issue #38), and trailerLineStarts (via
+	// trailerValueContinues) to enforce spec clause-10 termination of
+	// multi-line trailer values (issue #48).
+	m.trailerBlockStart, m.trailerLineStarts = findTrailerBlock(input)
 	output := &conventionalCommit{}
 	output.footers = make(map[string][]string)
 	output.typeconfig = m.typeConfig
@@ -641,7 +695,7 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		}
 
 		goto st0
-	tr151:
+	tr150:
 
 		// Append newlines
 		for m.countNewlines > 0 {
@@ -955,7 +1009,17 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 			goto _testEof33
 		}
 	stCase33:
-		if 32 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+		_widec = int16((m.data)[(m.p)])
+		if 10 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 10 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.trailerValueContinues() {
+				_widec += 256
+			}
+		}
+		if _widec == 522 {
+			goto tr42
+		}
+		if 32 <= _widec && _widec <= 126 {
 			goto tr42
 		}
 		goto st0
@@ -969,49 +1033,27 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 			goto _testEof130
 		}
 	stCase130:
-		if (m.data)[(m.p)] == 10 {
-			goto tr148
+		_widec = int16((m.data)[(m.p)])
+		if 10 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 10 {
+			_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+			if m.trailerValueContinues() {
+				_widec += 256
+			}
 		}
-		if 32 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
+		switch _widec {
+		case 266:
+			goto tr149
+		case 522:
+			goto st130
+		}
+		if 32 <= _widec && _widec <= 126 {
 			goto st130
 		}
 		goto st0
-	tr148:
+	tr149:
 
 		output.footers[m.currentFooterKey] = append(output.footers[m.currentFooterKey], string(m.text()))
 		m.emitInfo("valid commit message footer trailer", m.currentFooterKey, string(m.text()))
-
-		// Increment number of newlines to use in case we're still in the body
-		m.countNewlines++
-		m.lastNewline = m.p
-		m.emitDebug("found a newline", "pos", m.p)
-
-		// shouldRedirectToBody centralizes the decision of whether the next
-		// stretch of input should be parsed as body content rather than as
-		// the start of a footer trailer. Keeping the predicate in Go (and
-		// the fgoto in Ragel) means the action body Ragel emits at every
-		// callsite stays one line of conditional + fgoto, so the generated
-		// machine.go does not multiply the predicate logic across callsites.
-		if m.shouldRedirectToBody() {
-			// Snap the marker forward so body's appendBody window starts
-			// fresh on the upcoming line instead of replaying any stale
-			// >mark from earlier productions (description, last footer val,
-			// etc.). m.p currently points at the newline that terminated
-			// the previous production, so m.p + 1 is the first byte of the
-			// line we are about to treat as body content.
-			m.pb = m.p + 1
-			m.emitDebug("redirecting to body parsing", "pos", m.p)
-			{
-				goto st34
-			}
-		}
-		m.emitDebug("try to parse a footer trailer token", "pos", m.p)
-		{
-			goto st127
-		}
-
-		goto st131
-	tr150:
 
 		// Increment number of newlines to use in case we're still in the body
 		m.countNewlines++
@@ -1048,9 +1090,6 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 			goto _testEof131
 		}
 	stCase131:
-		if (m.data)[(m.p)] == 10 {
-			goto tr150
-		}
 		goto st0
 	st34:
 		if (m.p)++; (m.p) == (m.pe) {
@@ -1058,11 +1097,11 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		}
 	stCase34:
 		_widec = int16((m.data)[(m.p)])
-		_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+		_widec = 768 + (int16((m.data)[(m.p)]) - 0)
 		if m.p+2 < m.pe && m.data[m.p+1] == 10 && m.data[m.p+2] == 10 {
 			_widec += 256
 		}
-		if 256 <= _widec && _widec <= 511 {
+		if 768 <= _widec && _widec <= 1023 {
 			goto tr45
 		}
 		goto tr44
@@ -1071,7 +1110,7 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		m.pb = m.p
 
 		goto st132
-	tr152:
+	tr151:
 
 		// Append newlines
 		for m.countNewlines > 0 {
@@ -1092,14 +1131,14 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		}
 	stCase132:
 		_widec = int16((m.data)[(m.p)])
-		_widec = 256 + (int16((m.data)[(m.p)]) - 0)
+		_widec = 768 + (int16((m.data)[(m.p)]) - 0)
 		if m.p+2 < m.pe && m.data[m.p+1] == 10 && m.data[m.p+2] == 10 {
 			_widec += 256
 		}
-		if 256 <= _widec && _widec <= 511 {
-			goto tr152
+		if 768 <= _widec && _widec <= 1023 {
+			goto tr151
 		}
-		goto tr151
+		goto tr150
 	stCase35:
 		switch (m.data)[(m.p)] {
 		case 66:
@@ -1269,10 +1308,10 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		}
 	stCase133:
 		if (m.data)[(m.p)] == 10 {
-			goto tr154
+			goto tr153
 		}
 		goto st133
-	tr154:
+	tr153:
 
 		output.descr = string(m.text())
 		m.emitInfo("valid commit message description", "description", output.descr)
@@ -1948,10 +1987,10 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		}
 	stCase135:
 		if (m.data)[(m.p)] == 10 {
-			goto tr156
+			goto tr155
 		}
 		goto st135
-	tr156:
+	tr155:
 
 		output.descr = string(m.text())
 		m.emitInfo("valid commit message description", "description", output.descr)
@@ -2540,10 +2579,10 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		}
 	stCase137:
 		if (m.data)[(m.p)] == 10 {
-			goto tr158
+			goto tr157
 		}
 		goto st137
-	tr158:
+	tr157:
 
 		output.descr = string(m.text())
 		m.emitInfo("valid commit message description", "description", output.descr)
@@ -3566,7 +3605,7 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 				output.descr = string(m.text())
 				m.emitInfo("valid commit message description", "description", output.descr)
 
-			case 130:
+			case 33, 130:
 
 				output.footers[m.currentFooterKey] = append(output.footers[m.currentFooterKey], string(m.text()))
 				m.emitInfo("valid commit message footer trailer", m.currentFooterKey, string(m.text()))

--- a/parser/machine.go.rl
+++ b/parser/machine.go.rl
@@ -1,8 +1,9 @@
 package parser
 
 import (
-	"fmt"
 	"bytes"
+	"fmt"
+	"sort"
 
 	"github.com/leodido/go-conventionalcommits"
 	"github.com/sirupsen/logrus"
@@ -437,38 +438,39 @@ func (m *machine) shouldRedirectToBody() bool {
 // value should continue past the newline at m.p (clause-10
 // termination predicate).
 //
-// The newline is consumed iff:
+// At call time m.p is the index of the '\n' under consideration for
+// consumption into the value (data[m.p] == '\n'). The newline is
+// consumed iff ALL of:
+//   - there is at least one byte after it (else we are at EOF and
+//     there is nothing to continue into);
+//   - the byte right after it is NOT itself '\n' (a '\n' immediately
+//     after this one means data[m.p:m.p+2] is the blank-line gap that
+//     terminates the trailer block per the standard FSM contract);
 //   - the byte right after it is NOT the start of a real trailer line
 //     per the pre-scan (otherwise the next line is the next trailer
-//     and the value must terminate here), AND
-//   - the next byte pair is not the start of a blank-line gap
-//     (a blank line terminates the trailer block per the standard
-//     FSM contract; nothing about clause-10 changes that).
+//     and the value must terminate here per spec clause 10).
 //
-// The first condition is the new clause-10 behavior. The second
-// condition preserves pre-existing semantics. See issue #48.
+// See issue #48 and the §B.2 finding in PR #49's third-pass review:
+// previously the blank-line check looked at data[m.p+1] and
+// data[m.p+2], which is "is there a blank-line gap STARTING at the
+// next byte" — wrong question. The right question is "is the current
+// byte the FIRST half of a blank-line gap", i.e. data[m.p+1] == '\n'.
 func (m *machine) trailerValueContinues() bool {
 	// Reject if we're at or past EOF: nothing to continue into.
 	if m.p+1 >= m.pe {
 		return false
 	}
-	// Reject if a blank line follows: the trailer block ends there.
-	if m.p+2 < m.pe && m.data[m.p+1] == '\n' && m.data[m.p+2] == '\n' {
+	// Reject if the next byte is also '\n': data[m.p:m.p+2] is the
+	// blank-line gap that terminates the trailer block.
+	if m.data[m.p+1] == '\n' {
 		return false
 	}
 	// Reject if the next line is itself a real trailer line per the
-	// pre-scan. Binary search keeps this O(log n) per call.
+	// pre-scan. sort.SearchInts is the same O(log n) binary search,
+	// just shorter to read than the hand-rolled loop.
 	next := m.p + 1
-	lo, hi := 0, len(m.trailerLineStarts)
-	for lo < hi {
-		mid := int(uint(lo+hi) >> 1)
-		if m.trailerLineStarts[mid] < next {
-			lo = mid + 1
-		} else {
-			hi = mid
-		}
-	}
-	if lo < len(m.trailerLineStarts) && m.trailerLineStarts[lo] == next {
+	i := sort.SearchInts(m.trailerLineStarts, next)
+	if i < len(m.trailerLineStarts) && m.trailerLineStarts[i] == next {
 		return false
 	}
 

--- a/parser/machine.go.rl
+++ b/parser/machine.go.rl
@@ -237,6 +237,16 @@ action rewind {
 
 action blank_line_ahead { m.p + 2 < m.pe && m.data[m.p + 1] == 10 && m.data[m.p + 2] == 10 }
 
+# trailer_val_continues reports whether the FSM, currently poised to
+# consume the newline at m.p, should continue the in-progress trailer
+# value past that newline. The newline is consumed iff:
+#   - the line right after it is NOT a real trailer line (per the
+#     pre-scan), AND
+#   - the next byte pair is not a blank-line gap (which terminates the
+#     trailer block per the standard FSM contract).
+# This is the clause-10 termination predicate. See issue #48.
+action trailer_val_continues { m.trailerValueContinues() }
+
 # Machine definitions
 
 minimal_types = ('fix'i | 'feat'i);
@@ -264,7 +274,13 @@ trailer_tok = alnum+ (dash alnum+)*;
 
 trailer_sep = trailer_sep_breaking | (ws '#');
 
-trailer_val = print+;
+# A trailer value MAY contain spaces and newlines; parsing terminates
+# when the next line is a real trailer (per the pre-scan), or when a
+# blank line is encountered, or at EOF. The `when` guard on the nl
+# transition is what enforces clause-10 termination: the newline is
+# only consumed iff the in-progress value should continue past it.
+# See issue #48.
+trailer_val = (print | (nl when trailer_val_continues))+;
 
 trailer_init = trailer_tok_breaking >mark @err(rewind) trailer_sep_breaking >set_current_footer_key @err(rewind) |
                trailer_tok >mark @err(rewind) trailer_sep >set_current_footer_key @err(rewind);
@@ -277,7 +293,13 @@ trailer_beg := nl* $count_nl (trailer_init @complete_trailer_parsing)?;
 
 # Match a trailer value.
 # Then, ignoring newlines, continue trying to detect other trailers.
-trailer_end := trailer_val >mark %set_footer nl* $count_nl @start_trailer_parsing;
+# set_footer is fired explicitly on the terminating boundary (a non-
+# continuing newline OR EOF) instead of as a leaving action on
+# trailer_val itself, because Ragel's `%`-style leaving actions fire
+# on every loop-back transition inside `(...)+ ` — which would emit
+# the value after every consumed continuation newline (issue #48).
+trailer_end := (trailer_val >mark) $eof(set_footer)
+               ((nl when !trailer_val_continues) @set_footer $count_nl @start_trailer_parsing)?;
 
 # Match anything until two newlines (ie., a blank line).
 # Then, try detect a footer looking for a trailer token.
@@ -338,6 +360,14 @@ type machine struct {
 	// >start_trailer_parsing entry should fall through to the body
 	// machine instead. See issue #38.
 	trailerBlockStart int
+	// trailerLineStarts is the sorted list of byte offsets within data
+	// at which a real trailer line begins (the first line of the block
+	// plus every continuation that is itself trailer_init-shaped).
+	// Empty when no trailer block is present. It is consulted by
+	// trailerValueContinues to enforce spec clause-10 termination of
+	// multi-line trailer values: a value continues across a newline
+	// iff the next line is NOT registered here. See issue #48.
+	trailerLineStarts []int
 }
 
 func (m *machine) text() []byte {
@@ -400,6 +430,49 @@ func (m *machine) shouldRedirectToBody() bool {
 	// trailer token's first byte and the historical trailer_beg path
 	// is what we want.
 	return pos < m.trailerBlockStart
+}
+
+// trailerValueContinues is consulted by the trailer_val Ragel
+// production to decide whether the in-progress multi-line trailer
+// value should continue past the newline at m.p (clause-10
+// termination predicate).
+//
+// The newline is consumed iff:
+//   - the byte right after it is NOT the start of a real trailer line
+//     per the pre-scan (otherwise the next line is the next trailer
+//     and the value must terminate here), AND
+//   - the next byte pair is not the start of a blank-line gap
+//     (a blank line terminates the trailer block per the standard
+//     FSM contract; nothing about clause-10 changes that).
+//
+// The first condition is the new clause-10 behavior. The second
+// condition preserves pre-existing semantics. See issue #48.
+func (m *machine) trailerValueContinues() bool {
+	// Reject if we're at or past EOF: nothing to continue into.
+	if m.p+1 >= m.pe {
+		return false
+	}
+	// Reject if a blank line follows: the trailer block ends there.
+	if m.p+2 < m.pe && m.data[m.p+1] == '\n' && m.data[m.p+2] == '\n' {
+		return false
+	}
+	// Reject if the next line is itself a real trailer line per the
+	// pre-scan. Binary search keeps this O(log n) per call.
+	next := m.p + 1
+	lo, hi := 0, len(m.trailerLineStarts)
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if m.trailerLineStarts[mid] < next {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	if lo < len(m.trailerLineStarts) && m.trailerLineStarts[lo] == next {
+		return false
+	}
+
+	return true
 }
 
 func (m *machine) emitInfo(s string, args... interface{}) {
@@ -476,11 +549,14 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 	m.currentFooterKey = ""
 	m.countNewlines = 0
 	// Pre-compute the start offset of the trailing trailer block (or -1)
-	// once per Parse() call. The FSM consults this (via
-	// shouldRedirectToBody) to keep body parsing going past any
+	// AND the sorted offsets of every real-trailer line within that
+	// block, once per Parse() call. The FSM consults trailerBlockStart
+	// (via shouldRedirectToBody) to keep body parsing going past any
 	// trailer-shaped line that does not belong to the real trailer
-	// block. See issue #38.
-	m.trailerBlockStart = findTrailerBlockStart(input)
+	// block (issue #38), and trailerLineStarts (via
+	// trailerValueContinues) to enforce spec clause-10 termination of
+	// multi-line trailer values (issue #48).
+	m.trailerBlockStart, m.trailerLineStarts = findTrailerBlock(input)
 	output := &conventionalCommit{}
 	output.footers = make(map[string][]string)
 	output.typeconfig = m.typeConfig

--- a/parser/testcases.go
+++ b/parser/testcases.go
@@ -1206,6 +1206,124 @@ Signed-off-by: Leonardo Di Donato <some@email.com>`),
 		"",
 		nil,
 	},
+	// VALID / clause-8 shape: trailers separated by a blank line. The
+	// trailer_val_continues guard MUST treat the current \n as the
+	// first half of the blank-line gap and stop the value before it,
+	// rather than consuming this \n into the value and only stopping
+	// at the next one. Pins the §B.2 regression from PR #49's
+	// third-pass review.
+	{
+		"valid-issue-48-trailers-separated-by-blank-line",
+		[]byte("feat: x\n\nA: 1\n\nB: 2"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Footers: map[string][]string{
+				"a": {"1"},
+				"b": {"2"},
+			},
+			TypeConfig: 0,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Footers: map[string][]string{
+				"a": {"1"},
+				"b": {"2"},
+			},
+			TypeConfig: 0,
+		},
+		"",
+		nil,
+	},
+	// VALID / three trailers each separated by blank lines (clause 8).
+	// The leak surfaces on every trailer that is itself the last of a
+	// paragraph followed by a blank line — i.e. all but the last
+	// trailer in this shape.
+	{
+		"valid-issue-48-three-trailers-each-separated-by-blank-line",
+		[]byte("feat: x\n\nA: 1\n\nB: 2\n\nC: 3"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Footers: map[string][]string{
+				"a": {"1"},
+				"b": {"2"},
+				"c": {"3"},
+			},
+			TypeConfig: 0,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Footers: map[string][]string{
+				"a": {"1"},
+				"b": {"2"},
+				"c": {"3"},
+			},
+			TypeConfig: 0,
+		},
+		"",
+		nil,
+	},
+	// VALID / value followed by EXACTLY one trailing blank line at EOF.
+	// Mirrors `A: 1\n\n` — the blank-line gap before EOF must NOT be
+	// folded into the value. Pins the EOF-asymmetry sub-case of §B.2.
+	{
+		"valid-issue-48-trailer-then-trailing-blank-line-at-eof",
+		[]byte("feat: x\n\nA: 1\n\n"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Footers: map[string][]string{
+				"a": {"1"},
+			},
+			TypeConfig: 0,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Footers: map[string][]string{
+				"a": {"1"},
+			},
+			TypeConfig: 0,
+		},
+		"",
+		nil,
+	},
+	// VALID / Git-canonical shape: real-world commit message with a
+	// `Fixes #N` paragraph followed by a `Signed-off-by:` paragraph.
+	// This is the exact shape spec clause 8 documents and the one
+	// PR #49's third-pass review identified as silently-broken in the
+	// wild. Worth pinning verbatim.
+	{
+		"valid-issue-48-git-canonical-fixes-then-signed-off-by",
+		[]byte("feat: add new widget\n\nFixes #123\n\nSigned-off-by: Alice <alice@example.com>"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "add new widget",
+			Footers: map[string][]string{
+				"fixes":         {"123"},
+				"signed-off-by": {"Alice <alice@example.com>"},
+			},
+			TypeConfig: 0,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "add new widget",
+			Footers: map[string][]string{
+				"fixes":         {"123"},
+				"signed-off-by": {"Alice <alice@example.com>"},
+			},
+			TypeConfig: 0,
+		},
+		"",
+		nil,
+	},
 }
 
 var testCasesForFalcoTypes = []testCase{
@@ -3063,6 +3181,112 @@ see the issue for details.`),
 			Footers: map[string][]string{
 				"co-authored-by": {"Alice\n Co-authored-by: Bob"},
 				"reviewed-by":    {"Carol"},
+			},
+			TypeConfig: 1,
+		},
+		"",
+		nil,
+	},
+	// VALID / clause-8 shape: trailers separated by a blank line. The
+	// trailer_val_continues guard MUST treat the current \n as the
+	// first half of the blank-line gap and stop the value before it,
+	// rather than consuming this \n into the value and only stopping
+	// at the next one. Pins the §B.2 regression from PR #49's
+	// third-pass review.
+	{
+		"valid-issue-48-trailers-separated-by-blank-line",
+		[]byte("feat: x\n\nA: 1\n\nB: 2"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Footers: map[string][]string{
+				"a": {"1"},
+				"b": {"2"},
+			},
+			TypeConfig: 1,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Footers: map[string][]string{
+				"a": {"1"},
+				"b": {"2"},
+			},
+			TypeConfig: 1,
+		},
+		"",
+		nil,
+	},
+	{
+		"valid-issue-48-three-trailers-each-separated-by-blank-line",
+		[]byte("feat: x\n\nA: 1\n\nB: 2\n\nC: 3"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Footers: map[string][]string{
+				"a": {"1"},
+				"b": {"2"},
+				"c": {"3"},
+			},
+			TypeConfig: 1,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Footers: map[string][]string{
+				"a": {"1"},
+				"b": {"2"},
+				"c": {"3"},
+			},
+			TypeConfig: 1,
+		},
+		"",
+		nil,
+	},
+	{
+		"valid-issue-48-trailer-then-trailing-blank-line-at-eof",
+		[]byte("feat: x\n\nA: 1\n\n"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Footers: map[string][]string{
+				"a": {"1"},
+			},
+			TypeConfig: 1,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Footers: map[string][]string{
+				"a": {"1"},
+			},
+			TypeConfig: 1,
+		},
+		"",
+		nil,
+	},
+	{
+		"valid-issue-48-git-canonical-fixes-then-signed-off-by",
+		[]byte("feat: add new widget\n\nFixes #123\n\nSigned-off-by: Alice <alice@example.com>"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "add new widget",
+			Footers: map[string][]string{
+				"fixes":         {"123"},
+				"signed-off-by": {"Alice <alice@example.com>"},
+			},
+			TypeConfig: 1,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "add new widget",
+			Footers: map[string][]string{
+				"fixes":         {"123"},
+				"signed-off-by": {"Alice <alice@example.com>"},
 			},
 			TypeConfig: 1,
 		},

--- a/parser/testcases.go
+++ b/parser/testcases.go
@@ -3775,153 +3775,214 @@ BREAKING CHANGE #5`),
 		"",
 		nil,
 	},
-	// INVALID / invalid BREAKING CHANGE trailer separator after valid trailers
-	// VALID / until the last valid footer trailer
+	// VALID / per spec clause 10 a multi-line trailer value MAY contain
+	// arbitrary text including lines that look like a malformed
+	// BREAKING-CHANGE trailer; parsing only terminates at a real
+	// trailer line, a blank line, or EOF. See issue #48.
 	{
-		"invalid-breaking-change-invalid-separator-after-trailers",
+		"valid-issue-48-trailer-then-non-trailer-breaking-change-line",
 		[]byte(`fix: description
 
 Tested-by: Leo
 BREAKING CHANGE #5`),
-		false,
-		nil,
+		true,
 		&conventionalcommits.ConventionalCommit{
 			Type:        "fix",
 			Description: "description",
 			Footers: map[string][]string{
-				"tested-by": {"Leo"},
+				"tested-by": {"Leo\nBREAKING CHANGE #5"},
 			},
 			TypeConfig: 3,
 		},
-		fmt.Sprintf(ErrTrailer+ColumnPositionTemplate, " ", 48),
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "description",
+			Footers: map[string][]string{
+				"tested-by": {"Leo\nBREAKING CHANGE #5"},
+			},
+			TypeConfig: 3,
+		},
+		"",
 		nil,
 	},
-	// INVALID / incomplete BREAKING CHANGE trailer
-	// VALID / until the last valid footer trailer
+	// VALID / per spec clause 10: a `BREAKING CHANG: XYZ` line is
+	// not a trailer (typo in the token); it continues the previous
+	// trailer's value. See issue #48.
 	{
-		"invalid-breaking-change-incomplete-after-trailers",
+		"valid-issue-48-trailer-then-mistyped-breaking-change-line",
 		[]byte(`fix: description
 
 Tested-by: Leo
 BREAKING CHANG: XYZ`),
-		false,
-		nil,
+		true,
 		&conventionalcommits.ConventionalCommit{
 			Type:        "fix",
 			Description: "description",
 			Footers: map[string][]string{
-				"tested-by": {"Leo"},
+				"tested-by": {"Leo\nBREAKING CHANG: XYZ"},
 			},
 			TypeConfig: 3,
 		},
-		fmt.Sprintf(ErrTrailer+ColumnPositionTemplate, ":", 47),
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "description",
+			Footers: map[string][]string{
+				"tested-by": {"Leo\nBREAKING CHANG: XYZ"},
+			},
+			TypeConfig: 3,
+		},
+		"",
 		nil,
 	},
-	// INVALID / lowercase (space separated) BREAKING CHANGE trailer
-	// VALID / until the last valid footer trailer
+	// VALID / per spec clause 10: lowercase `breaking change` is not
+	// a real trailer token; the line continues the previous value.
+	// See issue #48.
 	{
-		"invalid-lowercase-space-separated-breaking-change-after-trailers",
+		"valid-issue-48-trailer-then-lowercase-breaking-change-line",
 		[]byte(`fix: description
 
 Tested-by: Leo
 breaking change: xyz`),
-		false,
-		nil,
+		true,
 		&conventionalcommits.ConventionalCommit{
 			Type:        "fix",
 			Description: "description",
 			Footers: map[string][]string{
-				"tested-by": {"Leo"},
+				"tested-by": {"Leo\nbreaking change: xyz"},
 			},
 			TypeConfig: 3,
 		},
-		fmt.Sprintf(ErrTrailer+ColumnPositionTemplate, "c", 42),
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "description",
+			Footers: map[string][]string{
+				"tested-by": {"Leo\nbreaking change: xyz"},
+			},
+			TypeConfig: 3,
+		},
+		"",
 		nil,
 	},
-	// INVALID / illegal trailer after valid trailer
-	// VALID / until the last valid footer trailer
+	// VALID / per spec clause 10: a continuation line beginning with
+	// `!` is not a trailer; it is part of the previous trailer's
+	// value. See issue #48.
 	{
-		"invalid-illegal-trailer-after-valid-trailer",
+		"valid-issue-48-trailer-then-bang-only-continuation",
 		[]byte(`fix: description
 
 Tested-by: Leo
 !`),
-		false,
-		nil,
+		true,
 		&conventionalcommits.ConventionalCommit{
 			Type:        "fix",
 			Description: "description",
 			Footers: map[string][]string{
-				"tested-by": {"Leo"},
+				"tested-by": {"Leo\n!"},
 			},
 			TypeConfig: 3,
 		},
-		fmt.Sprintf(ErrTrailer+ColumnPositionTemplate, "!", 33),
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "description",
+			Footers: map[string][]string{
+				"tested-by": {"Leo\n!"},
+			},
+			TypeConfig: 3,
+		},
+		"",
 		nil,
 	},
-	// INVALID / illegal trailer after valid trailer with an ending newline
-	// VALID / until the last valid footer trailer
+	// VALID / per spec clause 10: a continuation line of a single
+	// alphabetic char (here `a`) is not trailer-shaped; the trailing
+	// newline is dropped per the existing trailer-block contract.
+	// See issue #48.
 	{
-		"invalid-illegal-trailer-after-valid-trailer-with-ending-newline",
+		"valid-issue-48-trailer-then-alpha-continuation-with-trailing-newline",
 		[]byte(`fix: description
 
 Tested-by: Leo
 a
 `),
-		false,
-		nil,
+		true,
 		&conventionalcommits.ConventionalCommit{
 			Type:        "fix",
 			Description: "description",
 			Footers: map[string][]string{
-				"tested-by": {"Leo"},
+				"tested-by": {"Leo\na"},
 			},
 			TypeConfig: 3,
 		},
-		fmt.Sprintf(ErrTrailer+ColumnPositionTemplate, "\n", 34),
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "description",
+			Footers: map[string][]string{
+				"tested-by": {"Leo\na"},
+			},
+			TypeConfig: 3,
+		},
+		"",
 		nil,
 	},
-	// INVALID / incomplete trailer after valid trailer with an ending newline
-	// VALID / until the last valid footer trailer
+	// VALID / per spec clause 10: same as above but without the
+	// trailing newline (EOF mid-continuation). See issue #48.
 	{
-		"invalid-incomplete-trailer-after-valid-trailer-with-ending-newline",
+		"valid-issue-48-trailer-then-alpha-continuation-eof",
 		[]byte(`fix: description
 
 Tested-by: Leo
 a`),
-		false,
-		nil,
+		true,
 		&conventionalcommits.ConventionalCommit{
 			Type:        "fix",
 			Description: "description",
 			Footers: map[string][]string{
-				"tested-by": {"Leo"},
+				"tested-by": {"Leo\na"},
 			},
 			TypeConfig: 3,
 		},
-		fmt.Sprintf(ErrTrailerIncomplete+ColumnPositionTemplate, "a", 34),
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "description",
+			Footers: map[string][]string{
+				"tested-by": {"Leo\na"},
+			},
+			TypeConfig: 3,
+		},
+		"",
 		nil,
 	},
-	// INVALID / incomplete trailer after valid trailer
-	// VALID / until the last valid footer trailer
+	// VALID / per spec clause 10: `X-` is not trailer-shaped (a
+	// trailer token cannot end in a dash; trailer_init requires
+	// `alnum+ (- alnum+)*`), so it folds into the previous trailer's
+	// value; `Another-trailer: x` IS a real trailer line and starts
+	// a new trailer. See issue #48.
 	{
-		"invalid-incomplete-trailer-after-valid-trailer",
+		"valid-issue-48-trailer-then-dash-trailing-continuation-then-real-trailer",
 		[]byte(`fix: description
 
 Tested-by: Leo
 X-
 Another-trailer: x`),
-		false,
-		nil,
+		true,
 		&conventionalcommits.ConventionalCommit{
 			Type:        "fix",
 			Description: "description",
 			Footers: map[string][]string{
-				"tested-by": {"Leo"},
+				"tested-by":       {"Leo\nX-"},
+				"another-trailer": {"x"},
 			},
 			TypeConfig: 3,
 		},
-		fmt.Sprintf(ErrTrailer+ColumnPositionTemplate, "\n", 35),
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "description",
+			Footers: map[string][]string{
+				"tested-by":       {"Leo\nX-"},
+				"another-trailer": {"x"},
+			},
+			TypeConfig: 3,
+		},
+		"",
 		nil,
 	},
 }

--- a/parser/testcases.go
+++ b/parser/testcases.go
@@ -1094,6 +1094,118 @@ Signed-off-by: Leonardo Di Donato <some@email.com>`),
 		"",
 		nil,
 	},
+
+	// --- Reproducers for issue #48 (multi-line trailer values per spec
+	// clause 10: "A footer's value MAY contain spaces and newlines, and
+	// parsing MUST terminate when the next valid footer token/separator
+	// pair is observed").
+	// See https://github.com/leodido/go-conventionalcommits/issues/48
+
+	// VALID / single trailer with a multi-line value terminated by EOF.
+	{
+		"valid-issue-48-breaking-change-multiline-value-eof",
+		[]byte("fix: x\n\nBREAKING CHANGE: this wraps\nacross two lines"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "x",
+			Footers: map[string][]string{
+				"breaking-change": {"this wraps\nacross two lines"},
+			},
+			TypeConfig: 0,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "x",
+			Footers: map[string][]string{
+				"breaking-change": {"this wraps\nacross two lines"},
+			},
+			TypeConfig: 0,
+		},
+		"",
+		nil,
+	},
+	// VALID / multi-line trailer value followed by another single-line trailer.
+	{
+		"valid-issue-48-multiline-trailer-then-single-trailer",
+		[]byte("feat: x\n\nBREAKING CHANGE: long\nexplanation continues here\nReviewed-by: X"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Footers: map[string][]string{
+				"breaking-change": {"long\nexplanation continues here"},
+				"reviewed-by":     {"X"},
+			},
+			TypeConfig: 0,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Footers: map[string][]string{
+				"breaking-change": {"long\nexplanation continues here"},
+				"reviewed-by":     {"X"},
+			},
+			TypeConfig: 0,
+		},
+		"",
+		nil,
+	},
+	// VALID / multi-line trailer value where the continuation line begins
+	// with whitespace. Continuation must be retained verbatim, including
+	// the leading space, since a leading space disqualifies the line from
+	// being a trailer_init.
+	{
+		"valid-issue-48-multiline-trailer-value-indented-continuation",
+		[]byte("fix: x\n\nRefs: #123\n  also fixes #124"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "x",
+			Footers: map[string][]string{
+				"refs": {"#123\n  also fixes #124"},
+			},
+			TypeConfig: 0,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "x",
+			Footers: map[string][]string{
+				"refs": {"#123\n  also fixes #124"},
+			},
+			TypeConfig: 0,
+		},
+		"",
+		nil,
+	},
+	// VALID / continuation line that visually resembles a trailer but
+	// has a leading space (so it is NOT trailer-init-shaped) is part of
+	// the value of the trailer above; the real trailer below terminates.
+	{
+		"valid-issue-48-fake-trailer-continuation-then-real-trailer",
+		[]byte("fix: x\n\nCo-authored-by: Alice\n Co-authored-by: Bob\nReviewed-by: Carol"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "x",
+			Footers: map[string][]string{
+				"co-authored-by": {"Alice\n Co-authored-by: Bob"},
+				"reviewed-by":    {"Carol"},
+			},
+			TypeConfig: 0,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "x",
+			Footers: map[string][]string{
+				"co-authored-by": {"Alice\n Co-authored-by: Bob"},
+				"reviewed-by":    {"Carol"},
+			},
+			TypeConfig: 0,
+		},
+		"",
+		nil,
+	},
 }
 
 var testCasesForFalcoTypes = []testCase{
@@ -2852,6 +2964,105 @@ see the issue for details.`),
 			Body:        cctesting.StringAddress("body1\nRefs: 123"),
 			Footers: map[string][]string{
 				"reviewed-by": {"X"},
+			},
+			TypeConfig: 1,
+		},
+		"",
+		nil,
+	},
+
+	// --- Reproducers for issue #48 (multi-line trailer values per spec
+	// clause 10). See https://github.com/leodido/go-conventionalcommits/issues/48
+	{
+		"valid-issue-48-breaking-change-multiline-value-eof",
+		[]byte("fix: x\n\nBREAKING CHANGE: this wraps\nacross two lines"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "x",
+			Footers: map[string][]string{
+				"breaking-change": {"this wraps\nacross two lines"},
+			},
+			TypeConfig: 1,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "x",
+			Footers: map[string][]string{
+				"breaking-change": {"this wraps\nacross two lines"},
+			},
+			TypeConfig: 1,
+		},
+		"",
+		nil,
+	},
+	{
+		"valid-issue-48-multiline-trailer-then-single-trailer",
+		[]byte("feat: x\n\nBREAKING CHANGE: long\nexplanation continues here\nReviewed-by: X"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Footers: map[string][]string{
+				"breaking-change": {"long\nexplanation continues here"},
+				"reviewed-by":     {"X"},
+			},
+			TypeConfig: 1,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Description: "x",
+			Footers: map[string][]string{
+				"breaking-change": {"long\nexplanation continues here"},
+				"reviewed-by":     {"X"},
+			},
+			TypeConfig: 1,
+		},
+		"",
+		nil,
+	},
+	{
+		"valid-issue-48-multiline-trailer-value-indented-continuation",
+		[]byte("fix: x\n\nRefs: #123\n  also fixes #124"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "x",
+			Footers: map[string][]string{
+				"refs": {"#123\n  also fixes #124"},
+			},
+			TypeConfig: 1,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "x",
+			Footers: map[string][]string{
+				"refs": {"#123\n  also fixes #124"},
+			},
+			TypeConfig: 1,
+		},
+		"",
+		nil,
+	},
+	{
+		"valid-issue-48-fake-trailer-continuation-then-real-trailer",
+		[]byte("fix: x\n\nCo-authored-by: Alice\n Co-authored-by: Bob\nReviewed-by: Carol"),
+		true,
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "x",
+			Footers: map[string][]string{
+				"co-authored-by": {"Alice\n Co-authored-by: Bob"},
+				"reviewed-by":    {"Carol"},
+			},
+			TypeConfig: 1,
+		},
+		&conventionalcommits.ConventionalCommit{
+			Type:        "fix",
+			Description: "x",
+			Footers: map[string][]string{
+				"co-authored-by": {"Alice\n Co-authored-by: Bob"},
+				"reviewed-by":    {"Carol"},
 			},
 			TypeConfig: 1,
 		},

--- a/parser/trailer_scan.go
+++ b/parser/trailer_scan.go
@@ -7,6 +7,78 @@ import (
 	"bytes"
 )
 
+// findTrailerBlock returns both the start offset of the trailing
+// trailer block (or -1 if absent) AND the sorted list of byte offsets
+// of every line within that block whose first line is itself
+// trailer_init-shaped (the "real trailer lines"). The line-starts
+// table is empty when there is no trailer block.
+//
+// The line-starts table is what the FSM consults at runtime via
+// trailerValueContinues to enforce spec clause-10 termination of
+// multi-line trailer values: a value continues across a newline iff
+// the line right after the newline is NOT registered here. See issue
+// #48.
+//
+// findTrailerBlock is the canonical entry point for the parser; the
+// older findTrailerBlockStart is preserved as a thin wrapper for the
+// existing trailer_scan unit tests.
+func findTrailerBlock(data []byte) (start int, lineStarts []int) {
+	if len(data) == 0 {
+		return -1, nil
+	}
+
+	// Drop trailing newlines so they don't get mis-attributed.
+	end := len(data)
+	for end > 0 && data[end-1] == '\n' {
+		end--
+	}
+	if end == 0 {
+		return -1, nil
+	}
+
+	// Forward pass: record offsets of every non-blank line's first
+	// byte and whether each line is preceded by a blank-line gap.
+	allLineStart, blankBefore := scanLines(data, end)
+	if len(allLineStart) == 0 {
+		return -1, nil
+	}
+
+	// Reverse pass: walk from the bottom, extending the candidate
+	// trailer block across blank-line gaps when the line above the
+	// gap is itself trailer-shaped. This locates the block start.
+	candidate := -1
+	candidateLineIdx := -1
+	for i := len(allLineStart) - 1; i >= 0; i-- {
+		if !blankBefore[i] {
+			continue
+		}
+		if i == 0 {
+			break
+		}
+		if !isTrailerStartLine(lineAt(data, allLineStart[i], end)) {
+			break
+		}
+		candidate = allLineStart[i]
+		candidateLineIdx = i
+	}
+	if candidate < 0 {
+		return -1, nil
+	}
+
+	// Forward pass over just the lines inside the trailer block:
+	// classify each as a real-trailer line or a continuation line of
+	// the previous trailer's value. Only real-trailer lines go into
+	// the lineStarts table.
+	lineStarts = make([]int, 0, len(allLineStart)-candidateLineIdx)
+	for i := candidateLineIdx; i < len(allLineStart); i++ {
+		if isTrailerStartLine(lineAt(data, allLineStart[i], end)) {
+			lineStarts = append(lineStarts, allLineStart[i])
+		}
+	}
+
+	return candidate, lineStarts
+}
+
 // findTrailerBlockStart returns the byte offset, within data, at which
 // the trailing footer trailer block begins, or -1 if no such block is
 // present.
@@ -39,62 +111,16 @@ import (
 // Trailing newlines/whitespace at the end of the input are ignored
 // when locating the block.
 //
-// Performance: the implementation is one forward pass over data to
-// build the per-line offset table, plus one reverse pass over that
-// table that does at most one isTrailerStartLine check per blank-line
-// gap. Both passes are O(n) where n = len(data); no quadratic
-// LastIndex behavior, even on inputs with many trailer-shaped
-// paragraphs.
+// Performance: one forward pass over data to build the per-line
+// offset table, plus one reverse pass over that table that does at
+// most one isTrailerStartLine check per blank-line gap, plus one final
+// forward pass over the in-block lines. All three are O(n) where n =
+// len(data); no quadratic LastIndex behavior, even on inputs with
+// many trailer-shaped paragraphs.
 func findTrailerBlockStart(data []byte) int {
-	if len(data) == 0 {
-		return -1
-	}
+	start, _ := findTrailerBlock(data)
 
-	// Drop trailing newlines so they don't get mis-attributed.
-	end := len(data)
-	for end > 0 && data[end-1] == '\n' {
-		end--
-	}
-	if end == 0 {
-		return -1
-	}
-
-	// Forward pass: record the byte offset of the first byte of every
-	// non-blank line in data[:end] and whether that line is preceded
-	// by a blank-line gap. The first line (i == 0) is the description,
-	// blankBefore[0] is always false by convention.
-	lineStart, blankBefore := scanLines(data, end)
-	if len(lineStart) == 0 {
-		return -1
-	}
-
-	// Reverse pass: walk lines from the bottom up. Each blank-line gap
-	// either extends the trailer block (when the line right after the
-	// gap, i.e. the line at lineStart[i], is trailer-shaped) or
-	// terminates it. Continuation lines (no blank gap above them) are
-	// part of whatever block the line above them belongs to, so we
-	// don't classify them.
-	candidate := -1
-	for i := len(lineStart) - 1; i >= 0; i-- {
-		if !blankBefore[i] {
-			continue
-		}
-		if i == 0 {
-			// Would extend up to the description line; never classify
-			// the description as part of the trailer block.
-			return candidate
-		}
-		if !isTrailerStartLine(lineAt(data, lineStart[i], end)) {
-			// The line at lineStart[i] is not trailer-shaped. The
-			// previous candidate (set at a deeper line) is the answer.
-			return candidate
-		}
-		// Trailer-shaped first line of a sub-block: extend the block
-		// up to here and look for an even deeper gap.
-		candidate = lineStart[i]
-	}
-
-	return candidate
+	return start
 }
 
 // scanLines walks data[:end] once and returns:


### PR DESCRIPTION
Fixes #48

(Was stacked on #47; #47 has merged into `develop`, branch rebased onto it. Base retargeted to `develop`.)

## Problem

Conventional Commits v1.0.0 spec clause 10:

> A footer's value MAY contain spaces and newlines, and parsing MUST
> terminate when the next valid footer token/separator pair is observed.

Before this PR, `trailer_val` was `print+`, forbidding any newline inside a trailer value. Inputs such as

```
fix: x

BREAKING CHANGE: this wraps
across two lines
```

either lost the trailing line at EOF or raised `ErrTrailer` because the next line did not look like a fresh trailer.

## Approach

Extend the pre-scan introduced in #47 to also expose, per `Parse()` call, the sorted byte offsets of every real-trailer line inside the trailer block. Wire that table into the FSM via a Go predicate (`trailerValueContinues`) exposed as a Ragel `when` guard:

```ragel
trailer_val = (print | (nl when trailer_val_continues))+;
```

A newline inside a trailer value is consumed iff the byte right after it is NOT itself `\n` (i.e. the current `\n` is not the first half of a blank-line gap) AND the next line is NOT a real trailer line per the pre-scan. On any non-continuing newline (or EOF), `set_footer` fires once and parsing hands back to `start_trailer_parsing`.

`set_footer` is fired explicitly on the terminating boundary (`(nl when !trailer_val_continues) @set_footer`) and on EOF (`$eof(set_footer)`, attached to every state inside the `(...)+` loop) instead of as a Ragel `%`-style leaving action on `trailer_val` itself, because `%` actions fire on every loop-back transition inside `(...)+` and would flush the in-progress value once per consumed continuation newline.

## Commits

1. `test(parser): add reproducers for issue #48` — four reproducers each in `testCases` and `testCasesForConventionalTypes` covering BREAKING-CHANGE multi-line value at EOF, multi-line then single-line, indented continuation, and fake-trailer continuation followed by a real trailer.
2. `refactor(parser): extend pre-scan to expose per-line trailer offsets` — adds `findTrailerBlock` returning both the block start and the per-line trailer-offset table; preserves `findTrailerBlockStart` as a thin wrapper so the existing trailer_scan unit tests still exercise the same surface.
3. `fix(parser): support multi-line trailer values per spec clause 10` — wires the table into the FSM via the new `trailerValueContinues` predicate, restructures `trailer_val` / `trailer_end` accordingly, regenerates `parser/machine.go` from the `.rl`.
4. `test(parser): reclassify post-clause-10 freeform cases as valid` — seven freeform-types cases previously asserted that a non-trailer-shaped line following a valid trailer must trigger `ErrTrailer`/`ErrTrailerIncomplete`; per clause 10 those lines are valid continuations. Inputs are kept verbatim so this is a behavioral re-classification, not new coverage on top of the issue #48 reproducers above.
5. `test(parser): pin clause-8 blank-separated-trailers shape (RED)` — adds four reproducers (×2 type configs = 8 sub-cases) covering the spec-clause-8 shape (trailers separated by a blank line). RED at this commit so the repair surface in the next commit is reviewable in isolation.
6. `fix(parser): stop trailer value at first \n of blank-line gap` — fixes the §B.2 leak surfaced by the third-pass review: `trailerValueContinues` is called with `m.p` already pointing at the `\n` under consideration, so the blank-line check needs `data[m.p+1] == '\n'`, not `data[m.p+1] && data[m.p+2]`. Also folds in §B.6.2: binary-search → `sort.SearchInts` one-liner. Tests from commit 5 flip RED → GREEN.

## Verification

- `go test -race ./...`: green
- `golangci-lint run ./...`: 0 issues
