### PR TITLE
docs(readme): document trailer parsing behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,11 @@ The parser will still return the error (with the position information), so that 
 
 ## Trailer parsing
 
-The parser implements [Conventional Commits v1.0 clauses 8–10](https://www.conventionalcommits.org/en/v1.0.0/#specification) for trailers (a.k.a. footers). A few behaviors are worth calling out explicitly.
+The parser implements [Conventional Commits v1.0 clauses 8 to 10](https://www.conventionalcommits.org/en/v1.0.0/#specification) for trailers (also called footers). A few behaviors are worth calling out.
 
-### Trailer-shaped lines in the body are kept as body content
+### Trailer-shaped lines in the body stay in the body
 
-A line in the body that happens to look like a trailer (e.g. `Fixes #123`) is not promoted to a trailer. Only the contiguous run of trailer lines at the end of the message — separated from the body by at least one blank line — forms the trailer block.
+A line in the body that looks like a trailer (say, `Fixes #123`) is not picked up as one. The trailer block is only the run of trailer lines at the end of the message, with a blank line between it and the body.
 
 Given this commit message:
 
@@ -169,7 +169,7 @@ m, _ := parser.NewMachine(parser.WithTypes(conventionalcommits.TypesFreeForm)).P
 
 ### Multi-line trailer values
 
-Per clause 10, a trailer's value MAY contain spaces and newlines. Parsing terminates at the next valid trailer token-separator pair or a blank line.
+Clause 10 says a trailer's value can contain spaces and newlines. The value keeps going until the parser sees the next trailer (a `Token: value` line) or a blank line.
 
 Given this commit message:
 
@@ -193,7 +193,7 @@ m, _ := parser.NewMachine(parser.WithTypes(conventionalcommits.TypesFreeForm)).P
 
 ### Blank-separated trailers
 
-Per clause 8, trailers within the trailer block may be separated by a single blank line. Both forms parse identically.
+Clause 8 lets you put a blank line between trailers. Both layouts parse the same way.
 
 Blank-separated:
 
@@ -220,14 +220,16 @@ parser.NewMachine(...).Parse([]byte("feat: x\n\nFixes #1\nReviewed-by: X"))
 // Both yield: footers == map[fixes:[1] reviewed-by:[X]]
 ```
 
-### `Parse` return contract
+### What `Parse` returns
 
 In strict mode (best-effort off), `Parse` returns one of:
 
 - `(*ConventionalCommit, nil)` on success
 - `(nil, error)` on failure
 
-It never returns `(nil, nil)`. Best-effort mode may additionally return `(*ConventionalCommit, error)` when partial structure was recovered before the error position.
+It never returns `(nil, nil)`, so a `nil` first value always means the second value is the real error.
+
+In best-effort mode you can also get `(*ConventionalCommit, error)`: a partial commit recovered before the parser ran into the problem, plus the error telling you where it stopped.
 
 ## Performances
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,17 @@ The parser implements [Conventional Commits v1.0 clauses 8–10](https://www.con
 
 A line in the body that happens to look like a trailer (e.g. `Fixes #123`) is not promoted to a trailer. Only the contiguous run of trailer lines at the end of the message — separated from the body by at least one blank line — forms the trailer block.
 
+Given this commit message:
+
+```console
+fix: x
+
+This paragraph mentions
+Fixes #123 in passing.
+
+Reviewed-by: X
+```
+
 ```go
 in := []byte("fix: x\n\nThis paragraph mentions\nFixes #123 in passing.\n\nReviewed-by: X")
 m, _ := parser.NewMachine(parser.WithTypes(conventionalcommits.TypesFreeForm)).Parse(in)
@@ -141,6 +152,13 @@ m, _ := parser.NewMachine(parser.WithTypes(conventionalcommits.TypesFreeForm)).P
 ```
 
 A message whose body ends with a trailer-shaped line but has no real trailer block keeps the line as body content:
+
+```console
+fix: x
+
+This paragraph mentions
+Fixes #123 in passing.
+```
 
 ```go
 in := []byte("fix: x\n\nThis paragraph mentions\nFixes #123 in passing.")
@@ -151,7 +169,18 @@ m, _ := parser.NewMachine(parser.WithTypes(conventionalcommits.TypesFreeForm)).P
 
 ### Multi-line trailer values
 
-Per clause 10, a trailer's value MAY contain spaces and newlines. Parsing terminates at the next valid trailer token-separator pair or a blank line:
+Per clause 10, a trailer's value MAY contain spaces and newlines. Parsing terminates at the next valid trailer token-separator pair or a blank line.
+
+Given this commit message:
+
+```console
+fix: x
+
+BREAKING CHANGE: this is a long
+  explanation that wraps
+  across several lines
+Reviewed-by: X
+```
 
 ```go
 in := []byte("fix: x\n\nBREAKING CHANGE: this is a long\n  explanation that wraps\n  across several lines\nReviewed-by: X")
@@ -164,7 +193,26 @@ m, _ := parser.NewMachine(parser.WithTypes(conventionalcommits.TypesFreeForm)).P
 
 ### Blank-separated trailers
 
-Per clause 8, trailers within the trailer block may be separated by a single blank line. Both forms parse identically:
+Per clause 8, trailers within the trailer block may be separated by a single blank line. Both forms parse identically.
+
+Blank-separated:
+
+```console
+feat: x
+
+Fixes #1
+
+Reviewed-by: X
+```
+
+Adjacent:
+
+```console
+feat: x
+
+Fixes #1
+Reviewed-by: X
+```
 
 ```go
 parser.NewMachine(...).Parse([]byte("feat: x\n\nFixes #1\n\nReviewed-by: X"))

--- a/README.md
+++ b/README.md
@@ -125,6 +125,62 @@ The result will contain a `ConventionalCommit` struct instance with the `Type` a
 
 The parser will still return the error (with the position information), so that you can eventually use it.
 
+## Trailer parsing
+
+The parser implements [Conventional Commits v1.0 clauses 8–10](https://www.conventionalcommits.org/en/v1.0.0/#specification) for trailers (a.k.a. footers). A few behaviors are worth calling out explicitly.
+
+### Trailer-shaped lines in the body are kept as body content
+
+A line in the body that happens to look like a trailer (e.g. `Fixes #123`) is not promoted to a trailer. Only the contiguous run of trailer lines at the end of the message — separated from the body by at least one blank line — forms the trailer block.
+
+```go
+in := []byte("fix: x\n\nThis paragraph mentions\nFixes #123 in passing.\n\nReviewed-by: X")
+m, _ := parser.NewMachine(parser.WithTypes(conventionalcommits.TypesFreeForm)).Parse(in)
+// m.Body    == "This paragraph mentions\nFixes #123 in passing."
+// m.Footers == map[reviewed-by:[X]]
+```
+
+A message whose body ends with a trailer-shaped line but has no real trailer block keeps the line as body content:
+
+```go
+in := []byte("fix: x\n\nThis paragraph mentions\nFixes #123 in passing.")
+m, _ := parser.NewMachine(parser.WithTypes(conventionalcommits.TypesFreeForm)).Parse(in)
+// m.Body    == "This paragraph mentions\nFixes #123 in passing."
+// m.Footers == map[]
+```
+
+### Multi-line trailer values
+
+Per clause 10, a trailer's value MAY contain spaces and newlines. Parsing terminates at the next valid trailer token-separator pair or a blank line:
+
+```go
+in := []byte("fix: x\n\nBREAKING CHANGE: this is a long\n  explanation that wraps\n  across several lines\nReviewed-by: X")
+m, _ := parser.NewMachine(parser.WithTypes(conventionalcommits.TypesFreeForm)).Parse(in)
+// m.Footers == map[
+//   breaking-change: ["this is a long\n  explanation that wraps\n  across several lines"]
+//   reviewed-by:     ["X"]
+// ]
+```
+
+### Blank-separated trailers
+
+Per clause 8, trailers within the trailer block may be separated by a single blank line. Both forms parse identically:
+
+```go
+parser.NewMachine(...).Parse([]byte("feat: x\n\nFixes #1\n\nReviewed-by: X"))
+parser.NewMachine(...).Parse([]byte("feat: x\n\nFixes #1\nReviewed-by: X"))
+// Both yield: footers == map[fixes:[1] reviewed-by:[X]]
+```
+
+### `Parse` return contract
+
+In strict mode (best-effort off), `Parse` returns one of:
+
+- `(*ConventionalCommit, nil)` on success
+- `(nil, error)` on failure
+
+It never returns `(nil, nil)`. Best-effort mode may additionally return `(*ConventionalCommit, error)` when partial structure was recovered before the error position.
+
 ## Performances
 
 To run the benchmark suite execute the following command.


### PR DESCRIPTION
Fixes #51

## Problem

PRs #47 (issue #38) and #49 (issue #48) changed observable parser behavior in user-visible ways but did not update `README.md`. Consumers currently have to read the FSM (or the test suite) to learn what's accepted.

## Approach

Adds a new `## Trailer parsing` section to `README.md`, between the existing `Best effort` section and `Performances`. Four short subsections, each with a runnable example:

1. **Trailer-shaped lines in the body are kept as body content** — only the contiguous run of trailer lines at the end of the message, separated by a blank line, forms the trailer block (#47).
2. **Multi-line trailer values** per clause 10, terminating at the next trailer token-separator pair or a blank line (#49).
3. **Blank-separated trailers** per clause 8, showing that both adjacent and blank-separated forms yield identical maps.
4. **`Parse` return contract** — strict mode never returns `(nil, nil)`; best-effort mode may additionally return `(*ConventionalCommit, error)` when partial structure was recovered (#47).

## Verification

Every example in the new section was run verbatim against `develop` before committing:

| Example | Input | Verified output |
|---|---|---|
| ex1 | body with mid-paragraph `Fixes #123` then real trailer block | `body="This paragraph mentions\nFixes #123 in passing." footers={reviewed-by:[X]}` |
| ex2 | body-only with trailer-shaped tail | `body="...\nFixes #123 in passing." footers={}` |
| ex3 | multi-line `BREAKING CHANGE` value | value preserved verbatim across 3 lines |
| ex4a / ex4b | blank-separated vs adjacent trailers | both yield `{fixes:[1] reviewed-by:[X]}` |
| contract: strict failure | `"not a commit"` | `(nil, non-nil)` ✓ |
| contract: best-effort partial | `"fix: ok\nno blank line before body"` | `(*ConventionalCommit, error)` ✓ |

## Out of scope

- The post-#49 reclassification (commit `9ac8b69`) that turned some former `ErrTrailer` strict-mode failures into successful parses — that's a release-note item, not a README item, and the reviewer's suggested release-note bullet already covers it.
- The UTF-8 limitation tracked in #50.
- A `doc.go` package-level comment — README is sufficient for now.
