### PR TITLE
fix(parser): widen trailer values, scope, and free-form types to admit high bytes

### DIFF
--- a/common/common.rl
+++ b/common/common.rl
@@ -16,4 +16,24 @@ colon = 0x3A;
 
 exclamation = 0x21;
 
+# high_byte widens Ragel's built-in `print` class ([\x20-\x7e], ASCII
+# printable only) with the high-byte range [\x80-\xff] so productions
+# that capture user-supplied free-form text (trailer values, scope,
+# free-form types) accept any non-control byte transparently.
+#
+# The class is "any high byte", NOT "any valid UTF-8 byte". It admits
+# every byte in [\x80-\xff] including bytes that never appear in
+# valid UTF-8 (\xc0, \xc1, \xfe, \xff), lone leaders, lone
+# continuations, and overlong-encoding leaders. Validating that
+# captured slices form well-formed UTF-8 is the caller's
+# responsibility; an opt-in `WithStrictUTF8` option for that lives
+# in a follow-up PR.
+#
+# \x7f (DEL) is intentionally excluded; it is a control byte. C0
+# controls [\x00-\x1f] (except \n where the production allows it)
+# remain rejected.
+#
+# See https://github.com/leodido/go-conventionalcommits/issues/50
+high_byte = print | 0x80..0xff;
+
 }%%

--- a/common/common.rl
+++ b/common/common.rl
@@ -19,7 +19,9 @@ exclamation = 0x21;
 # high_byte widens Ragel's built-in `print` class ([\x20-\x7e], ASCII
 # printable only) with the high-byte range [\x80-\xff] so productions
 # that capture user-supplied free-form text (trailer values, scope,
-# free-form types) accept any non-control byte transparently.
+# free-form types) accept any non-control byte at the grammar layer.
+# This is an acceptance rule, not a promise that every exported field
+# preserves the input bytes unchanged.
 #
 # The class is "any high byte", NOT "any valid UTF-8 byte". It admits
 # every byte in [\x80-\xff] including bytes that never appear in
@@ -28,6 +30,11 @@ exclamation = 0x21;
 # captured slices form well-formed UTF-8 is the caller's
 # responsibility; an opt-in `WithStrictUTF8` option for that lives
 # in a follow-up PR.
+#
+# Export behavior is field-specific: trailer values are returned
+# without normalization, while type and scope pass through
+# strings.ToLower in parser/conventional_commit.go. That lowercases
+# valid cased Unicode and replaces ill-formed bytes with U+FFFD.
 #
 # \x7f (DEL) is intentionally excluded; it is a control byte. C0
 # controls [\x00-\x1f] (except \n where the production allows it)

--- a/parser/contract_test.go
+++ b/parser/contract_test.go
@@ -74,3 +74,64 @@ func TestParseNeverReturnsNilNil(t *testing.T) {
 	assert.NotNil(t, m)
 	assert.NoError(t, err)
 }
+
+// TestParseAcceptsUTF8 sweeps the byte-transparency contract added
+// by issue #50 across:
+//
+//	{TypeConfig: minimal, conventional, falco, freeform}
+//	x {input shape: trailer value, scope, free-form type}
+//	x {UTF-8 family: Latin-1, CJK, emoji, mid-multibyte truncation}
+//
+// The matrix exists in addition to the per-shape reproducers in
+// utf8_test.go to guarantee that NO type config silently regresses
+// the byte-transparency contract: e.g. if a future change hard-codes
+// `print` in one production but not another, this sweep notices.
+//
+// Falco-types is included because it shares the trailer / scope
+// productions with the other configs, so byte-transparency in those
+// productions must hold there too. Free-form-type-utf8 is only run
+// under TypesFreeForm because the other configs use literal-string
+// type alternations that intentionally reject anything but their
+// allow-list.
+func TestParseAcceptsUTF8(t *testing.T) {
+	type shape struct {
+		name             string
+		input            []byte
+		freeFormTypeOnly bool
+	}
+	shapes := []shape{
+		{"trailer-value-latin", []byte("feat: x\n\nReviewed-by: léodido"), false},
+		{"trailer-value-cjk", []byte("feat: x\n\nReviewed-by: 中文"), false},
+		{"trailer-value-emoji", []byte("feat: x\n\nReviewed-by: 👍"), false},
+		{"trailer-value-mid-multibyte-eof", []byte("feat: x\n\nReviewed-by: \xc3"), false},
+		{"scope-latin", []byte("feat(scôpe): x"), false},
+		{"scope-cjk", []byte("feat(中文): x"), false},
+		{"free-form-type-latin", []byte("féat: x"), true},
+		{"free-form-type-cjk", []byte("中文: x"), true},
+	}
+	configs := []struct {
+		name string
+		opt  conventionalcommits.MachineOption
+		t    conventionalcommits.TypeConfig
+	}{
+		{"minimal", WithTypes(conventionalcommits.TypesMinimal), conventionalcommits.TypesMinimal},
+		{"conventional", WithTypes(conventionalcommits.TypesConventional), conventionalcommits.TypesConventional},
+		{"falco", WithTypes(conventionalcommits.TypesFalco), conventionalcommits.TypesFalco},
+		{"freeform", WithTypes(conventionalcommits.TypesFreeForm), conventionalcommits.TypesFreeForm},
+	}
+	for _, cfg := range configs {
+		for _, s := range shapes {
+			if s.freeFormTypeOnly && cfg.t != conventionalcommits.TypesFreeForm {
+				continue
+			}
+			cfg, s := cfg, s
+			t.Run(cfg.name+"/"+s.name, func(t *testing.T) {
+				m, err := NewMachine(cfg.opt).Parse(s.input)
+				assert.NoError(t, err, "byte-transparency: input %q must parse", s.input)
+				if assert.NotNil(t, m, "byte-transparency: input %q must yield a message", s.input) {
+					assert.True(t, m.Ok(), "byte-transparency: input %q must produce an Ok() commit", s.input)
+				}
+			})
+		}
+	}
+}

--- a/parser/contract_test.go
+++ b/parser/contract_test.go
@@ -75,8 +75,8 @@ func TestParseNeverReturnsNilNil(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestParseAcceptsUTF8 sweeps the byte-transparency contract added
-// by issue #50 across:
+// TestParseAcceptsUTF8 sweeps the UTF-8/high-byte acceptance contract
+// added by issue #50 across:
 //
 //	{TypeConfig: minimal, conventional, falco, freeform}
 //	x {input shape: trailer value, scope, free-form type}
@@ -84,13 +84,13 @@ func TestParseNeverReturnsNilNil(t *testing.T) {
 //
 // The matrix exists in addition to the per-shape reproducers in
 // utf8_test.go to guarantee that NO type config silently regresses
-// the byte-transparency contract: e.g. if a future change hard-codes
-// `print` in one production but not another, this sweep notices.
+// grammar acceptance: e.g. if a future change hard-codes `print` in
+// one production but not another, this sweep notices.
 //
 // Falco-types is included because it shares the trailer / scope
-// productions with the other configs, so byte-transparency in those
-// productions must hold there too. Free-form-type-utf8 is only run
-// under TypesFreeForm because the other configs use literal-string
+// productions with the other configs, so high-byte acceptance in
+// those productions must hold there too. Free-form-type-utf8 is only
+// run under TypesFreeForm because the other configs use literal-string
 // type alternations that intentionally reject anything but their
 // allow-list.
 func TestParseAcceptsUTF8(t *testing.T) {
@@ -127,9 +127,9 @@ func TestParseAcceptsUTF8(t *testing.T) {
 			cfg, s := cfg, s
 			t.Run(cfg.name+"/"+s.name, func(t *testing.T) {
 				m, err := NewMachine(cfg.opt).Parse(s.input)
-				assert.NoError(t, err, "byte-transparency: input %q must parse", s.input)
-				if assert.NotNil(t, m, "byte-transparency: input %q must yield a message", s.input) {
-					assert.True(t, m.Ok(), "byte-transparency: input %q must produce an Ok() commit", s.input)
+				assert.NoError(t, err, "UTF-8 acceptance: input %q must parse", s.input)
+				if assert.NotNil(t, m, "UTF-8 acceptance: input %q must yield a message", s.input) {
+					assert.True(t, m.Ok(), "UTF-8 acceptance: input %q must produce an Ok() commit", s.input)
 				}
 			})
 		}

--- a/parser/conventional_commit.go
+++ b/parser/conventional_commit.go
@@ -26,6 +26,11 @@ func (c *conventionalCommit) minimal() bool {
 func (c *conventionalCommit) export() conventionalcommits.Message {
 	out := &conventionalcommits.ConventionalCommit{}
 	out.Exclamation = c.exclamation
+	// Type and Scope intentionally retain the parser's historical
+	// Unicode-aware lowercase normalization. Consequently, grammar
+	// acceptance of high bytes does not imply byte-for-byte export:
+	// cased Unicode is lowercased and ill-formed bytes become U+FFFD.
+	// Description, Body, and Footers do not pass through this step.
 	out.Type = strings.ToLower(c._type)
 	out.Description = c.descr
 	out.TypeConfig = c.typeconfig

--- a/parser/machine.go
+++ b/parser/machine.go
@@ -929,18 +929,18 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 			goto _testEof10
 		}
 	stCase10:
-		if (m.data)[(m.p)] == 41 {
+		switch (m.data)[(m.p)] {
+		case 40:
+			goto tr16
+		case 41:
 			goto tr18
+		case 127:
+			goto tr16
 		}
-		switch {
-		case (m.data)[(m.p)] > 39:
-			if 42 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
-				goto tr17
-			}
-		case (m.data)[(m.p)] >= 32:
-			goto tr17
+		if (m.data)[(m.p)] <= 31 {
+			goto tr16
 		}
-		goto tr16
+		goto tr17
 	tr17:
 
 		m.pb = m.p
@@ -951,18 +951,18 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 			goto _testEof11
 		}
 	stCase11:
-		if (m.data)[(m.p)] == 41 {
+		switch (m.data)[(m.p)] {
+		case 40:
+			goto tr16
+		case 41:
 			goto tr20
+		case 127:
+			goto tr16
 		}
-		switch {
-		case (m.data)[(m.p)] > 39:
-			if 42 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
-				goto st11
-			}
-		case (m.data)[(m.p)] >= 32:
-			goto st11
+		if (m.data)[(m.p)] <= 31 {
+			goto tr16
 		}
-		goto tr16
+		goto st11
 	tr18:
 
 		m.pb = m.p
@@ -1021,7 +1021,12 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		if _widec == 522 {
 			goto tr42
 		}
-		if 32 <= _widec && _widec <= 126 {
+		switch {
+		case _widec > 126:
+			if 128 <= _widec {
+				goto tr42
+			}
+		case _widec >= 32:
 			goto tr42
 		}
 		goto st0
@@ -1048,7 +1053,12 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		case 522:
 			goto st130
 		}
-		if 32 <= _widec && _widec <= 126 {
+		switch {
+		case _widec > 126:
+			if 128 <= _widec {
+				goto st130
+			}
+		case _widec >= 32:
 			goto st130
 		}
 		goto st0
@@ -1368,18 +1378,18 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 			goto _testEof45
 		}
 	stCase45:
-		if (m.data)[(m.p)] == 41 {
+		switch (m.data)[(m.p)] {
+		case 40:
+			goto tr16
+		case 41:
 			goto tr65
+		case 127:
+			goto tr16
 		}
-		switch {
-		case (m.data)[(m.p)] > 39:
-			if 42 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
-				goto tr64
-			}
-		case (m.data)[(m.p)] >= 32:
-			goto tr64
+		if (m.data)[(m.p)] <= 31 {
+			goto tr16
 		}
-		goto tr16
+		goto tr64
 	tr64:
 
 		m.pb = m.p
@@ -1390,18 +1400,18 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 			goto _testEof46
 		}
 	stCase46:
-		if (m.data)[(m.p)] == 41 {
+		switch (m.data)[(m.p)] {
+		case 40:
+			goto tr16
+		case 41:
 			goto tr67
+		case 127:
+			goto tr16
 		}
-		switch {
-		case (m.data)[(m.p)] > 39:
-			if 42 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
-				goto st46
-			}
-		case (m.data)[(m.p)] >= 32:
-			goto st46
+		if (m.data)[(m.p)] <= 31 {
+			goto tr16
 		}
-		goto tr16
+		goto st46
 	tr65:
 
 		m.pb = m.p
@@ -2047,18 +2057,18 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 			goto _testEof86
 		}
 	stCase86:
-		if (m.data)[(m.p)] == 41 {
+		switch (m.data)[(m.p)] {
+		case 40:
+			goto tr16
+		case 41:
 			goto tr109
+		case 127:
+			goto tr16
 		}
-		switch {
-		case (m.data)[(m.p)] > 39:
-			if 42 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
-				goto tr108
-			}
-		case (m.data)[(m.p)] >= 32:
-			goto tr108
+		if (m.data)[(m.p)] <= 31 {
+			goto tr16
 		}
-		goto tr16
+		goto tr108
 	tr108:
 
 		m.pb = m.p
@@ -2069,18 +2079,18 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 			goto _testEof87
 		}
 	stCase87:
-		if (m.data)[(m.p)] == 41 {
+		switch (m.data)[(m.p)] {
+		case 40:
+			goto tr16
+		case 41:
 			goto tr111
+		case 127:
+			goto tr16
 		}
-		switch {
-		case (m.data)[(m.p)] > 39:
-			if 42 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
-				goto st87
-			}
-		case (m.data)[(m.p)] >= 32:
-			goto st87
+		if (m.data)[(m.p)] <= 31 {
+			goto tr16
 		}
-		goto tr16
+		goto st87
 	tr109:
 
 		m.pb = m.p
@@ -2489,10 +2499,13 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		}
 		goto tr0
 	stCase116:
-		if 32 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
-			goto tr131
+		if (m.data)[(m.p)] == 127 {
+			goto tr0
 		}
-		goto tr0
+		if (m.data)[(m.p)] <= 31 {
+			goto tr0
+		}
+		goto tr131
 	tr131:
 
 		m.pb = m.p
@@ -2519,11 +2532,13 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 			goto st122
 		case 58:
 			goto st119
+		case 127:
+			goto tr6
 		}
-		if 32 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
-			goto st117
+		if (m.data)[(m.p)] <= 31 {
+			goto tr6
 		}
-		goto tr6
+		goto st117
 	tr133:
 
 		output.exclamation = true
@@ -2639,18 +2654,18 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 			goto _testEof122
 		}
 	stCase122:
-		if (m.data)[(m.p)] == 41 {
+		switch (m.data)[(m.p)] {
+		case 40:
+			goto tr16
+		case 41:
 			goto tr140
+		case 127:
+			goto tr16
 		}
-		switch {
-		case (m.data)[(m.p)] > 39:
-			if 42 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
-				goto tr139
-			}
-		case (m.data)[(m.p)] >= 32:
-			goto tr139
+		if (m.data)[(m.p)] <= 31 {
+			goto tr16
 		}
-		goto tr16
+		goto tr139
 	tr139:
 
 		m.pb = m.p
@@ -2661,18 +2676,18 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 			goto _testEof123
 		}
 	stCase123:
-		if (m.data)[(m.p)] == 41 {
+		switch (m.data)[(m.p)] {
+		case 40:
+			goto tr16
+		case 41:
 			goto tr142
+		case 127:
+			goto tr16
 		}
-		switch {
-		case (m.data)[(m.p)] > 39:
-			if 42 <= (m.data)[(m.p)] && (m.data)[(m.p)] <= 126 {
-				goto st123
-			}
-		case (m.data)[(m.p)] >= 32:
-			goto st123
+		if (m.data)[(m.p)] <= 31 {
+			goto tr16
 		}
-		goto tr16
+		goto st123
 	tr140:
 
 		m.pb = m.p

--- a/parser/machine.go.rl
+++ b/parser/machine.go.rl
@@ -256,6 +256,9 @@ conventional_types = ('build'i | 'ci'i | 'chore'i | 'docs'i | 'feat'i | 'fix'i |
 
 falco_types = ('build'i | 'ci'i | 'chore'i | 'docs'i | 'feat'i | 'fix'i | 'perf'i | 'new'i | 'revert'i | 'update'i | 'test'i | 'rule'i);
 
+# high_byte controls what the FSM can recognize. It does not define
+# the exported representation: type and scope are normalized by
+# conventionalCommit.export, while trailer values are not.
 free_form_types = high_byte+;
 
 scope = lpar ((high_byte* -- lpar) -- rpar) >mark %err(err_malformed_scope) %eof(err_malformed_scope_closing) %set_scope rpar;

--- a/parser/machine.go.rl
+++ b/parser/machine.go.rl
@@ -256,9 +256,9 @@ conventional_types = ('build'i | 'ci'i | 'chore'i | 'docs'i | 'feat'i | 'fix'i |
 
 falco_types = ('build'i | 'ci'i | 'chore'i | 'docs'i | 'feat'i | 'fix'i | 'perf'i | 'new'i | 'revert'i | 'update'i | 'test'i | 'rule'i);
 
-free_form_types = print+;
+free_form_types = high_byte+;
 
-scope = lpar ((print* -- lpar) -- rpar) >mark %err(err_malformed_scope) %eof(err_malformed_scope_closing) %set_scope rpar;
+scope = lpar ((high_byte* -- lpar) -- rpar) >mark %err(err_malformed_scope) %eof(err_malformed_scope_closing) %set_scope rpar;
 
 breaking = exclamation >set_exclamation;
 
@@ -281,7 +281,7 @@ trailer_sep = trailer_sep_breaking | (ws '#');
 # transition is what enforces clause-10 termination: the newline is
 # only consumed iff the in-progress value should continue past it.
 # See issue #48.
-trailer_val = (print | (nl when trailer_val_continues))+;
+trailer_val = (high_byte | (nl when trailer_val_continues))+;
 
 trailer_init = trailer_tok_breaking >mark @err(rewind) trailer_sep_breaking >set_current_footer_key @err(rewind) |
                trailer_tok >mark @err(rewind) trailer_sep >set_current_footer_key @err(rewind);

--- a/parser/utf8_test.go
+++ b/parser/utf8_test.go
@@ -192,6 +192,57 @@ func TestUTF8HighByteAcceptance(t *testing.T) {
 	}
 }
 
+// TestUTF8ExportNormalization distinguishes grammar acceptance from
+// the public representation returned by Parse. Type and Scope pass
+// through strings.ToLower during export, while trailer values are
+// exported without normalization.
+func TestUTF8ExportNormalization(t *testing.T) {
+	cases := []struct {
+		title     string
+		input     []byte
+		expectMsg func(t *testing.T, m cc.Message)
+	}{
+		{
+			title:     "uppercase-unicode-free-form-type-is-lowercased",
+			input:     []byte("FÉAT: x"),
+			expectMsg: expectType("féat"),
+		},
+		{
+			title:     "uppercase-unicode-scope-is-lowercased",
+			input:     []byte("feat(SCÔPE): x"),
+			expectMsg: expectScope("scôpe"),
+		},
+		{
+			title:     "malformed-free-form-type-becomes-replacement-rune",
+			input:     []byte{0xff, ':', ' ', 'x'},
+			expectMsg: expectType("\uFFFD"),
+		},
+		{
+			title:     "malformed-scope-becomes-replacement-rune",
+			input:     []byte{'f', 'e', 'a', 't', '(', 0xff, ')', ':', ' ', 'x'},
+			expectMsg: expectScope("\uFFFD"),
+		},
+		{
+			title: "malformed-trailer-value-is-preserved",
+			input: []byte{
+				'f', 'e', 'a', 't', ':', ' ', 'x', '\n', '\n',
+				'R', 'e', 'v', 'i', 'e', 'w', 'e', 'd', '-', 'b', 'y', ':', ' ', 0xff,
+			},
+			expectMsg: expectFooter("reviewed-by", "\xff"),
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.title, func(t *testing.T) {
+			m, err := NewMachine(WithTypes(cc.TypesFreeForm)).Parse(tc.input)
+			require.NoError(t, err)
+			require.NotNil(t, m)
+			tc.expectMsg(t, m)
+		})
+	}
+}
+
 // TestUTF8MidMultibyteEOFNoPanic asserts that an input ending mid-
 // multibyte does not panic the parser regardless of mode or type
 // config. Pinned separately because the panic surface is independent

--- a/parser/utf8_test.go
+++ b/parser/utf8_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// utf8Case pins the per-shape parse contract for an issue-#50 input
-// across one type config, in default mode (no options).
+// utf8Case pins the per-shape acceptance contract for an issue-#50
+// input across one type config, in default mode (no options).
 //
 // When expectOk is true, expectMsg is invoked to check the parsed
 // payload. When expectOk is false, expectErr is asserted as the exact
@@ -157,8 +157,8 @@ var utf8Cases = []utf8Case{
 	},
 }
 
-// TestUTF8ByteTransparency exercises the issue-#50 reproducer set in
-// default mode (no options).
+// TestUTF8HighByteAcceptance exercises the issue-#50 reproducer set
+// in default mode (no options).
 //
 // Best-effort mode is intentionally NOT covered here because it
 // swallows trailer-block errors and returns the description-only
@@ -166,9 +166,9 @@ var utf8Cases = []utf8Case{
 // decision being asserted.
 //
 // Strict-mode validation (the WithStrictUTF8 option, follow-up PR)
-// is intentionally NOT covered here either. This test pins what the
-// FSM does on its own; option behavior lives in its own test file.
-func TestUTF8ByteTransparency(t *testing.T) {
+// is intentionally NOT covered here either. This test pins which
+// bytes the FSM accepts; option behavior lives in its own test file.
+func TestUTF8HighByteAcceptance(t *testing.T) {
 	for _, tc := range utf8Cases {
 		tc := tc
 		t.Run(tc.title, func(t *testing.T) {

--- a/parser/utf8_test.go
+++ b/parser/utf8_test.go
@@ -31,93 +31,89 @@ type utf8Case struct {
 // pins:
 //   - which input shape (trailer value, scope, free-form type),
 //   - which type config it runs under,
-//   - the exact default-mode error today (RED), or the expected
-//     payload once the FSM is widened (GREEN).
-//
-// The RED commit registers these with expectOk == false and the
-// captured error string. The fix commit flips expectOk to true and
-// replaces expectErr with an expectMsg payload check. Bisecting the
-// branch shows exactly one commit per assertion flip.
+//   - the expected payload (GREEN), or the rejection message for the
+//     two negative cases that MUST continue to be rejected after the
+//     widening (DEL and SOH).
 var utf8Cases = []utf8Case{
 	// AC1: Latin-1 UTF-8 in trailer value (TypesMinimal).
 	{
 		title:     "trailer-value-utf8-latin/minimal",
 		input:     []byte("feat: x\n\nReviewed-by: léodido"),
 		types:     cc.TypesMinimal,
-		expectOk:  false,
-		expectErr: fmt.Sprintf(ErrEarly+ColumnPositionTemplate, "l", 23),
+		expectOk:  true,
+		expectMsg: expectFooter("reviewed-by", "léodido"),
 	},
 	// AC1: Latin-1 UTF-8 in trailer value (TypesConventional).
 	{
 		title:     "trailer-value-utf8-latin/conventional",
 		input:     []byte("feat: x\n\nReviewed-by: léodido"),
 		types:     cc.TypesConventional,
-		expectOk:  false,
-		expectErr: fmt.Sprintf(ErrEarly+ColumnPositionTemplate, "l", 23),
+		expectOk:  true,
+		expectMsg: expectFooter("reviewed-by", "léodido"),
 	},
 	// AC1: Latin-1 UTF-8 in trailer value (TypesFreeForm).
 	{
 		title:     "trailer-value-utf8-latin/freeform",
 		input:     []byte("feat: x\n\nReviewed-by: léodido"),
 		types:     cc.TypesFreeForm,
-		expectOk:  false,
-		expectErr: fmt.Sprintf(ErrEarly+ColumnPositionTemplate, "l", 23),
+		expectOk:  true,
+		expectMsg: expectFooter("reviewed-by", "léodido"),
 	},
 	// AC2: 4-byte UTF-8 (emoji) in trailer value.
 	{
 		title:     "trailer-value-utf8-emoji/minimal",
 		input:     []byte("feat: x\n\nReviewed-by: 👍"),
 		types:     cc.TypesMinimal,
-		expectOk:  false,
-		expectErr: fmt.Sprintf(ErrEarly+ColumnPositionTemplate, " ", 22),
+		expectOk:  true,
+		expectMsg: expectFooter("reviewed-by", "👍"),
 	},
 	// AC3: UTF-8 in scope (TypesMinimal).
 	{
 		title:     "scope-utf8/minimal",
 		input:     []byte("feat(scôpe): x"),
 		types:     cc.TypesMinimal,
-		expectOk:  false,
-		expectErr: fmt.Sprintf(ErrScope+ColumnPositionTemplate, "Ã", 7),
+		expectOk:  true,
+		expectMsg: expectScope("scôpe"),
 	},
 	// AC3: UTF-8 in scope (TypesConventional).
 	{
 		title:     "scope-utf8/conventional",
 		input:     []byte("feat(scôpe): x"),
 		types:     cc.TypesConventional,
-		expectOk:  false,
-		expectErr: fmt.Sprintf(ErrScope+ColumnPositionTemplate, "Ã", 7),
+		expectOk:  true,
+		expectMsg: expectScope("scôpe"),
 	},
 	// AC3: UTF-8 in scope (TypesFreeForm).
 	{
 		title:     "scope-utf8/freeform",
 		input:     []byte("feat(scôpe): x"),
 		types:     cc.TypesFreeForm,
-		expectOk:  false,
-		expectErr: fmt.Sprintf(ErrScope+ColumnPositionTemplate, "Ã", 7),
+		expectOk:  true,
+		expectMsg: expectScope("scôpe"),
 	},
 	// AC4: UTF-8 inside a free-form type (`féat`).
 	{
 		title:     "free-form-type-utf8-mid/freeform",
 		input:     []byte("féat: x"),
 		types:     cc.TypesFreeForm,
-		expectOk:  false,
-		expectErr: fmt.Sprintf(ErrColon+ColumnPositionTemplate, "Ã", 1),
+		expectOk:  true,
+		expectMsg: expectType("féat"),
 	},
 	// AC4: free-form type made entirely of UTF-8 bytes (`中文`).
 	{
 		title:     "free-form-type-utf8-all/freeform",
 		input:     []byte("中文: x"),
 		types:     cc.TypesFreeForm,
-		expectOk:  false,
-		expectErr: fmt.Sprintf(ErrType+ColumnPositionTemplate, "ä", 0),
+		expectOk:  true,
+		expectMsg: expectType("中文"),
 	},
 	// AC5: mixed ASCII + UTF-8 in trailer value.
 	{
 		title:     "trailer-value-mixed-ascii-utf8/minimal",
 		input:     []byte("feat: x\n\nReviewed-by: leo & léo"),
 		types:     cc.TypesMinimal,
-		expectOk:  false,
-		expectErr: fmt.Sprintf(ErrEarly+ColumnPositionTemplate, "l", 29),
+		expectOk:  true,
+		expectMsg: expectFooter("reviewed-by", "leo & léo"),
 	},
 	// AC6: multi-line trailer value with CJK UTF-8 across the line
 	// boundary.
@@ -125,22 +121,24 @@ var utf8Cases = []utf8Case{
 		title:     "trailer-value-multiline-cjk/minimal",
 		input:     []byte("feat: x\n\nBREAKING CHANGE: 中文\n  说明"),
 		types:     cc.TypesMinimal,
-		expectOk:  false,
-		expectErr: fmt.Sprintf(ErrEarly+ColumnPositionTemplate, " ", 26),
+		expectOk:  true,
+		expectMsg: expectFooter("breaking-change", "中文\n  说明"),
 	},
 	// AC7: trailer value ending mid-multibyte at EOF (truncated UTF-8
-	// leader byte). Today this is rejected; after #50 the byte is
-	// captured opaquely and the parser does not panic.
+	// leader byte). The byte is captured opaquely; the parser does
+	// not panic. Validating UTF-8 well-formedness is the caller's
+	// responsibility (an opt-in option for that lives in a follow-up
+	// PR).
 	{
 		title:     "trailer-value-mid-multibyte-eof/minimal",
 		input:     []byte("feat: x\n\nReviewed-by: \xc3"),
 		types:     cc.TypesMinimal,
-		expectOk:  false,
-		expectErr: fmt.Sprintf(ErrEarly+ColumnPositionTemplate, " ", 22),
+		expectOk:  true,
+		expectMsg: expectFooter("reviewed-by", "\xc3"),
 	},
-	// AC8: DEL (\x7f) in a trailer value MUST continue to be rejected
-	// after #50: the widened class is `(print | 0x80..0xff)`, which
-	// still excludes \x7f.
+	// AC8: DEL (\x7f) in a trailer value MUST continue to be rejected:
+	// the widened class is `(print | 0x80..0xff)`, which still
+	// excludes \x7f.
 	{
 		title:     "trailer-value-del-still-rejected/minimal",
 		input:     []byte("feat: x\n\nReviewed-by: a\x7fb"),
@@ -148,8 +146,8 @@ var utf8Cases = []utf8Case{
 		expectOk:  false,
 		expectErr: fmt.Sprintf(ErrEarly+ColumnPositionTemplate, "a", 23),
 	},
-	// AC9: SOH (\x01) in a trailer value MUST continue to be rejected
-	// after #50: control bytes are not in `(print | 0x80..0xff)`.
+	// AC9: SOH (\x01) in a trailer value MUST continue to be rejected:
+	// control bytes are not in `(print | 0x80..0xff)`.
 	{
 		title:     "trailer-value-control-still-rejected/minimal",
 		input:     []byte("feat: x\n\nReviewed-by: a\x01b"),
@@ -160,8 +158,7 @@ var utf8Cases = []utf8Case{
 }
 
 // TestUTF8ByteTransparency exercises the issue-#50 reproducer set in
-// default mode (no options). RED at the test-only commit, GREEN after
-// the FSM is widened.
+// default mode (no options).
 //
 // Best-effort mode is intentionally NOT covered here because it
 // swallows trailer-block errors and returns the description-only
@@ -223,5 +220,36 @@ func TestUTF8MidMultibyteEOFNoPanic(t *testing.T) {
 				_, _ = NewMachine(WithTypes(tc), WithBestEffort()).Parse(in)
 			}()
 		}
+	}
+}
+
+// expectFooter returns a payload check that asserts the parsed
+// commit has a footer with the given key whose first value equals
+// want.
+func expectFooter(key, want string) func(t *testing.T, m cc.Message) {
+	return func(t *testing.T, m cc.Message) {
+		c := m.(*cc.ConventionalCommit)
+		require.Contains(t, c.Footers, key, "missing footer %q", key)
+		require.NotEmpty(t, c.Footers[key], "footer %q has no values", key)
+		assert.Equal(t, want, c.Footers[key][0])
+	}
+}
+
+// expectScope returns a payload check that asserts the parsed commit
+// has the given scope.
+func expectScope(want string) func(t *testing.T, m cc.Message) {
+	return func(t *testing.T, m cc.Message) {
+		c := m.(*cc.ConventionalCommit)
+		require.NotNil(t, c.Scope, "expected scope, got nil")
+		assert.Equal(t, want, *c.Scope)
+	}
+}
+
+// expectType returns a payload check that asserts the parsed commit
+// has the given type.
+func expectType(want string) func(t *testing.T, m cc.Message) {
+	return func(t *testing.T, m cc.Message) {
+		c := m.(*cc.ConventionalCommit)
+		assert.Equal(t, want, c.Type)
 	}
 }

--- a/parser/utf8_test.go
+++ b/parser/utf8_test.go
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2020- Leonardo Di Donato <leodidonato@gmail.com>
+package parser
+
+import (
+	"fmt"
+	"testing"
+
+	cc "github.com/leodido/go-conventionalcommits"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// utf8Case pins the per-shape parse contract for an issue-#50 input
+// across one type config, in default mode (no options).
+//
+// When expectOk is true, expectMsg is invoked to check the parsed
+// payload. When expectOk is false, expectErr is asserted as the exact
+// error string.
+type utf8Case struct {
+	title     string
+	input     []byte
+	types     cc.TypeConfig
+	expectOk  bool
+	expectErr string                           // exact match when expectOk == false
+	expectMsg func(t *testing.T, m cc.Message) // payload check when expectOk == true
+}
+
+// utf8Cases is the canonical issue-#50 reproducer set. Each entry
+// pins:
+//   - which input shape (trailer value, scope, free-form type),
+//   - which type config it runs under,
+//   - the exact default-mode error today (RED), or the expected
+//     payload once the FSM is widened (GREEN).
+//
+// The RED commit registers these with expectOk == false and the
+// captured error string. The fix commit flips expectOk to true and
+// replaces expectErr with an expectMsg payload check. Bisecting the
+// branch shows exactly one commit per assertion flip.
+var utf8Cases = []utf8Case{
+	// AC1: Latin-1 UTF-8 in trailer value (TypesMinimal).
+	{
+		title:     "trailer-value-utf8-latin/minimal",
+		input:     []byte("feat: x\n\nReviewed-by: léodido"),
+		types:     cc.TypesMinimal,
+		expectOk:  false,
+		expectErr: fmt.Sprintf(ErrEarly+ColumnPositionTemplate, "l", 23),
+	},
+	// AC1: Latin-1 UTF-8 in trailer value (TypesConventional).
+	{
+		title:     "trailer-value-utf8-latin/conventional",
+		input:     []byte("feat: x\n\nReviewed-by: léodido"),
+		types:     cc.TypesConventional,
+		expectOk:  false,
+		expectErr: fmt.Sprintf(ErrEarly+ColumnPositionTemplate, "l", 23),
+	},
+	// AC1: Latin-1 UTF-8 in trailer value (TypesFreeForm).
+	{
+		title:     "trailer-value-utf8-latin/freeform",
+		input:     []byte("feat: x\n\nReviewed-by: léodido"),
+		types:     cc.TypesFreeForm,
+		expectOk:  false,
+		expectErr: fmt.Sprintf(ErrEarly+ColumnPositionTemplate, "l", 23),
+	},
+	// AC2: 4-byte UTF-8 (emoji) in trailer value.
+	{
+		title:     "trailer-value-utf8-emoji/minimal",
+		input:     []byte("feat: x\n\nReviewed-by: 👍"),
+		types:     cc.TypesMinimal,
+		expectOk:  false,
+		expectErr: fmt.Sprintf(ErrEarly+ColumnPositionTemplate, " ", 22),
+	},
+	// AC3: UTF-8 in scope (TypesMinimal).
+	{
+		title:     "scope-utf8/minimal",
+		input:     []byte("feat(scôpe): x"),
+		types:     cc.TypesMinimal,
+		expectOk:  false,
+		expectErr: fmt.Sprintf(ErrScope+ColumnPositionTemplate, "Ã", 7),
+	},
+	// AC3: UTF-8 in scope (TypesConventional).
+	{
+		title:     "scope-utf8/conventional",
+		input:     []byte("feat(scôpe): x"),
+		types:     cc.TypesConventional,
+		expectOk:  false,
+		expectErr: fmt.Sprintf(ErrScope+ColumnPositionTemplate, "Ã", 7),
+	},
+	// AC3: UTF-8 in scope (TypesFreeForm).
+	{
+		title:     "scope-utf8/freeform",
+		input:     []byte("feat(scôpe): x"),
+		types:     cc.TypesFreeForm,
+		expectOk:  false,
+		expectErr: fmt.Sprintf(ErrScope+ColumnPositionTemplate, "Ã", 7),
+	},
+	// AC4: UTF-8 inside a free-form type (`féat`).
+	{
+		title:     "free-form-type-utf8-mid/freeform",
+		input:     []byte("féat: x"),
+		types:     cc.TypesFreeForm,
+		expectOk:  false,
+		expectErr: fmt.Sprintf(ErrColon+ColumnPositionTemplate, "Ã", 1),
+	},
+	// AC4: free-form type made entirely of UTF-8 bytes (`中文`).
+	{
+		title:     "free-form-type-utf8-all/freeform",
+		input:     []byte("中文: x"),
+		types:     cc.TypesFreeForm,
+		expectOk:  false,
+		expectErr: fmt.Sprintf(ErrType+ColumnPositionTemplate, "ä", 0),
+	},
+	// AC5: mixed ASCII + UTF-8 in trailer value.
+	{
+		title:     "trailer-value-mixed-ascii-utf8/minimal",
+		input:     []byte("feat: x\n\nReviewed-by: leo & léo"),
+		types:     cc.TypesMinimal,
+		expectOk:  false,
+		expectErr: fmt.Sprintf(ErrEarly+ColumnPositionTemplate, "l", 29),
+	},
+	// AC6: multi-line trailer value with CJK UTF-8 across the line
+	// boundary.
+	{
+		title:     "trailer-value-multiline-cjk/minimal",
+		input:     []byte("feat: x\n\nBREAKING CHANGE: 中文\n  说明"),
+		types:     cc.TypesMinimal,
+		expectOk:  false,
+		expectErr: fmt.Sprintf(ErrEarly+ColumnPositionTemplate, " ", 26),
+	},
+	// AC7: trailer value ending mid-multibyte at EOF (truncated UTF-8
+	// leader byte). Today this is rejected; after #50 the byte is
+	// captured opaquely and the parser does not panic.
+	{
+		title:     "trailer-value-mid-multibyte-eof/minimal",
+		input:     []byte("feat: x\n\nReviewed-by: \xc3"),
+		types:     cc.TypesMinimal,
+		expectOk:  false,
+		expectErr: fmt.Sprintf(ErrEarly+ColumnPositionTemplate, " ", 22),
+	},
+	// AC8: DEL (\x7f) in a trailer value MUST continue to be rejected
+	// after #50: the widened class is `(print | 0x80..0xff)`, which
+	// still excludes \x7f.
+	{
+		title:     "trailer-value-del-still-rejected/minimal",
+		input:     []byte("feat: x\n\nReviewed-by: a\x7fb"),
+		types:     cc.TypesMinimal,
+		expectOk:  false,
+		expectErr: fmt.Sprintf(ErrEarly+ColumnPositionTemplate, "a", 23),
+	},
+	// AC9: SOH (\x01) in a trailer value MUST continue to be rejected
+	// after #50: control bytes are not in `(print | 0x80..0xff)`.
+	{
+		title:     "trailer-value-control-still-rejected/minimal",
+		input:     []byte("feat: x\n\nReviewed-by: a\x01b"),
+		types:     cc.TypesMinimal,
+		expectOk:  false,
+		expectErr: fmt.Sprintf(ErrEarly+ColumnPositionTemplate, "a", 23),
+	},
+}
+
+// TestUTF8ByteTransparency exercises the issue-#50 reproducer set in
+// default mode (no options). RED at the test-only commit, GREEN after
+// the FSM is widened.
+//
+// Best-effort mode is intentionally NOT covered here because it
+// swallows trailer-block errors and returns the description-only
+// commit, which is a separate contract from the reject/accept
+// decision being asserted.
+//
+// Strict-mode validation (the WithStrictUTF8 option, follow-up PR)
+// is intentionally NOT covered here either. This test pins what the
+// FSM does on its own; option behavior lives in its own test file.
+func TestUTF8ByteTransparency(t *testing.T) {
+	for _, tc := range utf8Cases {
+		tc := tc
+		t.Run(tc.title, func(t *testing.T) {
+			m, err := NewMachine(WithTypes(tc.types)).Parse(tc.input)
+
+			if tc.expectOk {
+				assert.NoError(t, err)
+				require.NotNil(t, m, "expected non-nil message for valid input %q", tc.input)
+				assert.True(t, m.Ok())
+				if tc.expectMsg != nil {
+					tc.expectMsg(t, m)
+				}
+
+				return
+			}
+
+			assert.Nil(t, m)
+			assert.Error(t, err)
+			assert.EqualError(t, err, tc.expectErr)
+		})
+	}
+}
+
+// TestUTF8MidMultibyteEOFNoPanic asserts that an input ending mid-
+// multibyte does not panic the parser regardless of mode or type
+// config. Pinned separately because the panic surface is independent
+// of the success/failure of the parse.
+func TestUTF8MidMultibyteEOFNoPanic(t *testing.T) {
+	inputs := [][]byte{
+		[]byte("feat: x\n\nReviewed-by: \xc3"),
+		[]byte("feat: x\n\nReviewed-by: \xe4\xb8"),
+		[]byte("feat: x\n\nReviewed-by: \xf0\x9f\x91"),
+	}
+	configs := []cc.TypeConfig{
+		cc.TypesMinimal,
+		cc.TypesConventional,
+		cc.TypesFalco,
+		cc.TypesFreeForm,
+	}
+	for _, in := range inputs {
+		for _, tc := range configs {
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Errorf("Parse panicked on input %q (config %d): %v", in, tc, r)
+					}
+				}()
+				_, _ = NewMachine(WithTypes(tc)).Parse(in)
+				_, _ = NewMachine(WithTypes(tc), WithBestEffort()).Parse(in)
+			}()
+		}
+	}
+}


### PR DESCRIPTION
Fixes #50

## Contract

This PR fixes issue #50 by widening **grammar acceptance** in the three affected Ragel productions. It does not promise byte-for-byte export for every parsed field.

- `trailer_val`, `scope`, and `free_form_types` accept ASCII printable bytes plus `[\x80-\xff]`, so valid UTF-8 is no longer rejected there.
- `high_byte` is deliberately a superset of valid UTF-8. It also admits malformed and truncated high-byte sequences; well-formedness validation remains a caller concern in this PR.
- Export behavior stays field-specific:
  - trailer values are returned without normalization;
  - type and scope retain their historical `strings.ToLower` normalization, so valid cased Unicode is lowercased and ill-formed bytes become U+FFFD;
  - description and body are not changed by this PR and do not pass through that normalization.

The new tests pin both layers separately: which bytes the FSM accepts, and what the public `Message` exports.

## What changed

Ragel's built-in `print` class is exactly `[\x20-\x7e]` (ASCII printable only). In the affected productions, any byte above `\x7f` previously aborted the FSM with `early exit`, `illegal character`, or `expecting colon`, depending on the active production.

This PR introduces:

```ragel
high_byte = print | 0x80..0xff;
```

and uses it for trailer values, scopes, and free-form types. Description and body already accepted high bytes through `any` / `(any - nl)`.

## What this PR deliberately does not do

- It does not validate UTF-8 well-formedness. The widened class admits lone leaders, lone continuations, overlong-encoding leaders, and bytes such as `\xc0`, `\xc1`, `\xfe`, and `\xff`. An opt-in `WithStrictUTF8` option is proposed in the stacked follow-up PR.
- It does not widen `trailer_tok`. Footer keys remain ASCII alphanumeric, intentionally, per spec.
- It does not change the existing type/scope lowercase normalization.

## Why the grammar change is sound

- `high_byte` is exactly `[32..126, 128..255]`. DEL (`\x7f`) and C0 controls (`\x00..\x1f`, except `\n` where a production permits it) remain rejected.
- `free_form_types_main` uses guarded concatenation against `(`, `!`, and `:`. High bytes cannot collide with those ASCII delimiters, so priority resolution is unchanged.
- The scope set difference still excludes `(` and `)`; high bytes cannot collide with either.
- The trailer-value continuation guard inspects only `\n`; high bytes cannot collide with it.
- Trailer pre-scan helpers inspect only `\n` and ASCII alphanumeric footer keys.

## Observable behavior

Valid UTF-8 that was previously rejected in trailer values, scopes, or free-form types now parses. Callers that relied on rejection of high bytes will see those bytes admitted by the grammar.

For malformed high-byte input, the exported result depends on the field: trailer values preserve the captured bytes, while type and scope are transformed by `strings.ToLower` and therefore contain U+FFFD for ill-formed bytes.

## Commits

| # | Subject |
|---|---|
| 1 | `test(parser): add UTF-8 reproducers for trailer_val / scope / free_form_types (RED)` |
| 2 | `refactor(parser): introduce high_byte class in common.rl` |
| 3 | `fix(parser): widen trailer_val / scope / free_form_types to admit high bytes` |
| 4 | `test(parser): pin UTF-8 byte-transparency contract sweep` |
| 5 | `test(parser): describe issue 50 as UTF-8 acceptance` |
| 6 | `test(parser): pin exported high-byte normalization` |
| 7 | `docs(parser): distinguish grammar acceptance from export` |

The stack remains bisectable. Commits 1–4 implement and sweep the grammar fix. Commit 5 corrects the contract terminology, commit 6 pins Unicode lowercasing and malformed-byte export behavior, and commit 7 documents the grammar/export boundary without changing generated parser output.

## Test impact

| Test | Coverage |
|---|---|
| `TestUTF8HighByteAcceptance` | 14 per-shape acceptance/rejection cases |
| `TestUTF8MidMultibyteEOFNoPanic` | 12 input/config combinations, in strict and best-effort parser modes |
| `TestParseAcceptsUTF8` | 26 cross-config grammar-acceptance cases |
| `TestUTF8ExportNormalization` | 5 cases covering Unicode lowercase and malformed-byte export |

Validation performed on the final stack:

- `go test -race ./...`
- `make build`
- regenerated `parser/machine.go` is byte-for-byte unchanged

## Deferred follow-up

- **`WithStrictUTF8` option:** the stacked follow-up PR adds opt-in UTF-8 well-formedness validation.
- **README documentation:** deferred until the option's API is finalized.
