### PR TITLE
docs(canary): exercise label workflow

### DIFF
--- a/tools/label-workflow-canary.md
+++ b/tools/label-workflow-canary.md
@@ -1,0 +1,6 @@
+# Label workflow canary
+
+This disposable file exists only to exercise the repository's pull-request
+label workflow after its first deployment to `develop`.
+
+The pull request carrying it is not intended to merge.


### PR DESCRIPTION
Disposable canary for the newly deployed pull-request label workflow.

This pull request is not intended to merge.
