### PR TITLE
fix(ci): permit pull request label mutations

### DIFF
--- a/.github/scripts/test-label-workflow.sh
+++ b/.github/scripts/test-label-workflow.sh
@@ -75,11 +75,11 @@ assert_contains "$classify_job" "gh api --paginate --slurp" "changed-files pagin
 # shellcheck disable=SC2016 # Assert literal Actions expressions.
 assert_contains "$classify_job" 'labels: ${{ steps.classify.outputs.labels }}' "classifier output"
 
-assert_contains "$apply_job" "issues: write" "apply permissions"
+assert_contains "$apply_job" "pull-requests: write" "apply permissions"
 apply_write_permissions=$(awk '/^[[:space:]]+[a-z-]+: write$/ { count++ } END { print count + 0 }' <<<"$apply_job")
 assert_eq "$apply_write_permissions" "1" "apply has exactly one write permission"
 assert_not_contains "$apply_job" "contents:" "apply permissions"
-assert_not_contains "$apply_job" "pull-requests:" "apply permissions"
+assert_not_contains "$apply_job" "issues:" "apply permissions"
 assert_not_contains "$apply_job" "uses:" "apply execution boundary"
 assert_not_contains "$apply_job" "actions/" "apply execution boundary"
 assert_not_contains "$apply_job" "checkout" "apply execution boundary"

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      issues: write
+      pull-requests: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Why

The first live `pull_request_target` canary on #57 classified the expected labels (`ci`, `tools`) but failed when the apply job attempted its additive label `POST`:

```text
gh: Resource not accessible by integration (HTTP 403)
```

The run's setup logs confirmed that the job received exactly `Issues: write`. The expected labels already exist, repository workflow permissions allow writes, and the preceding label read succeeded. This isolates the failure to the permission used for pull-request label mutation.

Failed canary run: https://github.com/leodido/go-conventionalcommits/actions/runs/29589978387

## What changed

- Replace `issues: write` with `pull-requests: write` on the apply job.
- Update the privilege-boundary regression to require `pull-requests: write`, reject `issues:`, and continue asserting that the job has exactly one write permission.

This replaces one permission rather than adding a second. The classify job remains read-only, and the apply job still has no checkout, action, build, cache, install, artifact, or PR-controlled shell input.

## Validation

- Test-first proof: the updated regression failed with `missing pull-requests: write` before the workflow changed, then passed afterward.
- `go test -race -covermode=atomic ./...`
- label-workflow regression harness
- ShellCheck
- YAML parsing
- `actionlint` v1.7.7
- independent focused review: no Critical, Important, or Minor findings

After merge, editing draft canary #57 will trigger the corrected default-branch workflow for live confirmation.

## Expected bootstrap failure

This PR's own `apply desired labels` check is expected to reproduce the 403. `pull_request_target` loads its workflow definition from `develop`, so it cannot exercise the permission change carried by this PR before that change merges. The read-only classifier and ordinary regression/test checks remain meaningful; `develop` is not branch-protected, so this known old-workflow failure does not create a merge deadlock.
