### PR TITLE
ci(actions): pin Node 24 releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the source code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.24'
           check-latest: true

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -38,12 +38,12 @@ jobs:
       PR_TITLE: ${{ github.event.pull_request.title }}
       PR_BODY: ${{ github.event.pull_request.body }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
 
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: false

--- a/.github/workflows/labels-bootstrap.yml
+++ b/.github/workflows/labels-bootstrap.yml
@@ -32,7 +32,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the source code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.24'
           check-latest: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the source code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # Avoid running against a shallow clone
 
@@ -25,7 +25,7 @@ jobs:
         run: git fetch --force --tags
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.24'
           check-latest: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  action-pins:
+    name: action pin regressions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the source code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Test action pin policy
+        run: go test ./tools/actionpins
+
+      - name: Run action pin policy
+        run: go run ./tools/actionpins
+
   label-workflow:
     name: label workflow regressions
     runs-on: ubuntu-latest
@@ -22,10 +44,10 @@ jobs:
       contents: read
     steps:
       - name: Check out the source code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.24'
           cache: false
@@ -46,10 +68,10 @@ jobs:
 
     steps:
       - name: Check out the source code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Go ${{ matrix.go }}
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ matrix.go }}
           check-latest: true

--- a/.github/workflows/validate-title.yml
+++ b/.github/workflows/validate-title.yml
@@ -25,11 +25,11 @@ jobs:
     env:
       PR_TITLE: ${{ github.event.pull_request.title }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/rwtodd/Go.Sed v0.0.0-20230610052213-ba3e9c186f0a
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -14,5 +15,4 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.17.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/tools/actionpins/main.go
+++ b/tools/actionpins/main.go
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2026- Leonardo Di Donato <leodidonato@gmail.com>
+
+// Command actionpins verifies that this repository's GitHub Actions workflows
+// use reviewed, immutable action references.
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	checkoutSHA     = "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+	checkoutVersion = "v7.0.0"
+	setupGoSHA      = "b7ad1dad31e06c5925ef5d2fc7ad053ef454303e"
+	setupGoVersion  = "v7.0.0"
+)
+
+var fullCommitSHA = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+func main() {
+	workflows := flag.String("workflows", ".github/workflows", "directory containing workflow YAML files")
+	flag.Parse()
+	if flag.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "usage: actionpins [-workflows directory]")
+		os.Exit(2)
+	}
+
+	if err := checkWorkflows(*workflows); err != nil {
+		fmt.Fprintf(os.Stderr, "actionpins: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("action pin tests: PASS")
+}
+
+type policyState struct {
+	seenCheckout bool
+	seenSetupGo  bool
+}
+
+func checkWorkflows(workflows string) error {
+	paths, err := workflowPaths(workflows)
+	if err != nil {
+		return err
+	}
+
+	var state policyState
+	for _, path := range paths {
+		if err := checkWorkflow(path, &state); err != nil {
+			return err
+		}
+	}
+
+	if !state.seenCheckout {
+		return fmt.Errorf("no actions/checkout reference found")
+	}
+	if !state.seenSetupGo {
+		return fmt.Errorf("no actions/setup-go reference found")
+	}
+	return nil
+}
+
+func workflowPaths(root string) ([]string, error) {
+	var paths []string
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+
+		extension := strings.ToLower(filepath.Ext(path))
+		if extension == ".yml" || extension == ".yaml" {
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func checkWorkflow(path string, state *policyState) error {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	decoder := yaml.NewDecoder(bytes.NewReader(contents))
+	var document yaml.Node
+	if err := decoder.Decode(&document); err != nil {
+		return fmt.Errorf("%s: parse workflow: %w", path, err)
+	}
+	var extra yaml.Node
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("%s: workflow must contain exactly one YAML document", path)
+		}
+		return fmt.Errorf("%s: parse workflow: %w", path, err)
+	}
+	return checkDocument(path, &document, state)
+}
+
+func checkDocument(path string, document *yaml.Node, state *policyState) error {
+	if document.Kind != yaml.DocumentNode || len(document.Content) != 1 {
+		return nodeError(path, document, "workflow must contain exactly one YAML document")
+	}
+
+	root, err := mappingNode(document.Content[0])
+	if err != nil {
+		return nodeError(path, document.Content[0], "workflow root must be a mapping")
+	}
+	_, jobsNode, found, err := mappingEntry(root, "jobs")
+	if err != nil {
+		return nodeError(path, root, "cannot inspect jobs")
+	}
+	if !found {
+		return nil
+	}
+
+	jobs, err := mappingNode(jobsNode)
+	if err != nil {
+		return nodeError(path, jobsNode, "jobs must be a mapping")
+	}
+	// GitHub Actions executes only reusable-job and step-level uses fields.
+	// Deliberately ignore arbitrary data keys named "uses" in env or inputs.
+	for index := 0; index < len(jobs.Content); index += 2 {
+		if err := checkJob(path, jobs.Content[index+1], state); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkJob(path string, node *yaml.Node, state *policyState) error {
+	job, err := mappingNode(node)
+	if err != nil {
+		return nodeError(path, node, "job must be a mapping")
+	}
+
+	_, usesNode, found, err := mappingEntry(job, "uses")
+	if err != nil {
+		return nodeError(path, job, "cannot inspect reusable workflow reference")
+	}
+	if found {
+		if _, err := checkUses(path, usesNode, state); err != nil {
+			return err
+		}
+	}
+
+	_, stepsNode, found, err := mappingEntry(job, "steps")
+	if err != nil {
+		return nodeError(path, job, "cannot inspect steps")
+	}
+	if !found {
+		return nil
+	}
+	return checkSteps(path, stepsNode, state)
+}
+
+func checkSteps(path string, node *yaml.Node, state *policyState) error {
+	steps, err := sequenceNode(node)
+	if err != nil {
+		return nodeError(path, node, "steps must be a sequence")
+	}
+	for _, stepNode := range steps.Content {
+		step, err := mappingNode(stepNode)
+		if err != nil {
+			return nodeError(path, stepNode, "step must be a mapping")
+		}
+
+		_, usesNode, found, err := mappingEntry(step, "uses")
+		if err != nil {
+			return nodeError(path, step, "cannot inspect action reference")
+		}
+		if !found {
+			continue
+		}
+
+		action, err := checkUses(path, usesNode, state)
+		if err != nil {
+			return err
+		}
+		if strings.EqualFold(action, "actions/checkout") {
+			if err := checkCheckoutInputs(path, step); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func checkUses(path string, node *yaml.Node, state *policyState) (string, error) {
+	actionRef, value, err := scalarValue(node)
+	if err != nil {
+		return "", nodeError(path, node, "uses value must be a string")
+	}
+	if strings.HasPrefix(actionRef, "./") {
+		// Local actions execute checked-out repository code, so they are not
+		// external supply-chain references and GitHub does not permit a ref.
+		return "", nil
+	}
+	if strings.HasPrefix(actionRef, "docker://") {
+		return "", nodeError(path, value, "Docker actions are not allowed")
+	}
+
+	action, ref, hasRef := strings.Cut(actionRef, "@")
+	if !hasRef || action == "" {
+		return "", nodeError(path, value, "external action has no ref: %s", actionRef)
+	}
+	if !fullCommitSHA.MatchString(ref) {
+		return "", nodeError(path, value, "external action is not pinned to a full commit: %s", actionRef)
+	}
+
+	switch strings.ToLower(action) {
+	case "actions/checkout":
+		state.seenCheckout = true
+		if actionRef != "actions/checkout@"+checkoutSHA {
+			return "", nodeError(path, value, "expected actions/checkout@%s", checkoutSHA)
+		}
+		if value.LineComment != "# "+checkoutVersion {
+			return "", nodeError(path, value, "expected # %s annotation", checkoutVersion)
+		}
+	case "actions/setup-go":
+		state.seenSetupGo = true
+		if actionRef != "actions/setup-go@"+setupGoSHA {
+			return "", nodeError(path, value, "expected actions/setup-go@%s", setupGoSHA)
+		}
+		if value.LineComment != "# "+setupGoVersion {
+			return "", nodeError(path, value, "expected # %s annotation", setupGoVersion)
+		}
+	}
+	return action, nil
+}
+
+func checkCheckoutInputs(path string, step *yaml.Node) error {
+	_, withNode, found, err := mappingEntry(step, "with")
+	if err != nil {
+		return nodeError(path, step, "cannot inspect checkout inputs")
+	}
+	if !found {
+		return nil
+	}
+
+	with, err := mappingNode(withNode)
+	if err != nil {
+		return nodeError(path, withNode, "checkout inputs must be a mapping")
+	}
+	unsafeKey, _, found, err := mappingEntry(with, "allow-unsafe-pr-checkout")
+	if err != nil {
+		return nodeError(path, with, "cannot inspect checkout inputs")
+	}
+	if found {
+		return nodeError(path, unsafeKey, "allow-unsafe-pr-checkout must not be configured")
+	}
+	return nil
+}
+
+func mappingEntry(mapping *yaml.Node, name string) (*yaml.Node, *yaml.Node, bool, error) {
+	mapping, err := mappingNode(mapping)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	for index := 0; index < len(mapping.Content); index += 2 {
+		key, value := mapping.Content[index], mapping.Content[index+1]
+		keyValue, _, err := scalarValue(key)
+		if err == nil && keyValue == name {
+			return key, value, true, nil
+		}
+	}
+	return nil, nil, false, nil
+}
+
+func mappingNode(node *yaml.Node) (*yaml.Node, error) {
+	node, err := dereferenceNode(node)
+	if err != nil || node.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("not a mapping")
+	}
+	return node, nil
+}
+
+func sequenceNode(node *yaml.Node) (*yaml.Node, error) {
+	node, err := dereferenceNode(node)
+	if err != nil || node.Kind != yaml.SequenceNode {
+		return nil, fmt.Errorf("not a sequence")
+	}
+	return node, nil
+}
+
+func scalarValue(node *yaml.Node) (string, *yaml.Node, error) {
+	node, err := dereferenceNode(node)
+	if err != nil || node.Kind != yaml.ScalarNode {
+		return "", node, fmt.Errorf("not a scalar")
+	}
+	return node.Value, node, nil
+}
+
+func dereferenceNode(node *yaml.Node) (*yaml.Node, error) {
+	seen := make(map[*yaml.Node]struct{})
+	for node != nil && node.Kind == yaml.AliasNode {
+		if _, exists := seen[node]; exists {
+			return nil, fmt.Errorf("cyclic alias")
+		}
+		seen[node] = struct{}{}
+		node = node.Alias
+	}
+	if node == nil {
+		return nil, fmt.Errorf("nil node")
+	}
+	return node, nil
+}
+
+func nodeError(path string, node *yaml.Node, format string, args ...any) error {
+	return fmt.Errorf("%s:%d: %s", path, node.Line, fmt.Sprintf(format, args...))
+}

--- a/tools/actionpins/main.go
+++ b/tools/actionpins/main.go
@@ -70,6 +70,7 @@ func checkWorkflows(workflows string) error {
 	if !state.seenSetupGo {
 		return fmt.Errorf("no actions/setup-go reference found")
 	}
+
 	return nil
 }
 
@@ -87,12 +88,15 @@ func workflowPaths(root string) ([]string, error) {
 		if extension == ".yml" || extension == ".yaml" {
 			paths = append(paths, path)
 		}
+
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
+
 	sort.Strings(paths)
+
 	return paths, nil
 }
 
@@ -112,8 +116,10 @@ func checkWorkflow(path string, state *policyState) error {
 		if err == nil {
 			return fmt.Errorf("%s: workflow must contain exactly one YAML document", path)
 		}
+
 		return fmt.Errorf("%s: parse workflow: %w", path, err)
 	}
+
 	return checkDocument(path, &document, state)
 }
 
@@ -145,6 +151,7 @@ func checkDocument(path string, document *yaml.Node, state *policyState) error {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -159,8 +166,8 @@ func checkJob(path string, node *yaml.Node, state *policyState) error {
 		return nodeError(path, job, "cannot inspect reusable workflow reference")
 	}
 	if found {
-		if _, err := checkUses(path, usesNode, state); err != nil {
-			return err
+		if _, checkErr := checkUses(path, usesNode, state); checkErr != nil {
+			return checkErr
 		}
 	}
 
@@ -171,6 +178,7 @@ func checkJob(path string, node *yaml.Node, state *policyState) error {
 	if !found {
 		return nil
 	}
+
 	return checkSteps(path, stepsNode, state)
 }
 
@@ -203,6 +211,7 @@ func checkSteps(path string, node *yaml.Node, state *policyState) error {
 			}
 		}
 	}
+
 	return nil
 }
 
@@ -246,6 +255,7 @@ func checkUses(path string, node *yaml.Node, state *policyState) (string, error)
 			return "", nodeError(path, value, "expected # %s annotation", setupGoVersion)
 		}
 	}
+
 	return action, nil
 }
 
@@ -269,6 +279,7 @@ func checkCheckoutInputs(path string, step *yaml.Node) error {
 	if found {
 		return nodeError(path, unsafeKey, "allow-unsafe-pr-checkout must not be configured")
 	}
+
 	return nil
 }
 
@@ -284,6 +295,7 @@ func mappingEntry(mapping *yaml.Node, name string) (*yaml.Node, *yaml.Node, bool
 			return key, value, true, nil
 		}
 	}
+
 	return nil, nil, false, nil
 }
 
@@ -292,6 +304,7 @@ func mappingNode(node *yaml.Node) (*yaml.Node, error) {
 	if err != nil || node.Kind != yaml.MappingNode {
 		return nil, fmt.Errorf("not a mapping")
 	}
+
 	return node, nil
 }
 
@@ -300,6 +313,7 @@ func sequenceNode(node *yaml.Node) (*yaml.Node, error) {
 	if err != nil || node.Kind != yaml.SequenceNode {
 		return nil, fmt.Errorf("not a sequence")
 	}
+
 	return node, nil
 }
 
@@ -308,6 +322,7 @@ func scalarValue(node *yaml.Node) (string, *yaml.Node, error) {
 	if err != nil || node.Kind != yaml.ScalarNode {
 		return "", node, fmt.Errorf("not a scalar")
 	}
+
 	return node.Value, node, nil
 }
 
@@ -323,6 +338,7 @@ func dereferenceNode(node *yaml.Node) (*yaml.Node, error) {
 	if node == nil {
 		return nil, fmt.Errorf("nil node")
 	}
+
 	return node, nil
 }
 

--- a/tools/actionpins/main_test.go
+++ b/tools/actionpins/main_test.go
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2026- Leonardo Di Donato <leodidonato@gmail.com>
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const baselineWorkflow = `name: action-pins fixture
+on: workflow_dispatch
+jobs:
+  baseline:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+`
+
+func TestCheckWorkflows(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		workflow string
+		wantErr  string
+	}{
+		{
+			name: "accepts reviewed baseline",
+		},
+		{
+			name: "accepts local action",
+			workflow: `jobs:
+  local:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./local-action
+`,
+		},
+		{
+			name: "rejects Docker action",
+			workflow: `jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://example.invalid/action:latest
+`,
+			wantErr: "Docker actions are not allowed",
+		},
+		{
+			name: "rejects quoted Docker uses key",
+			workflow: `jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - "uses": docker://example.invalid/action:latest
+`,
+			wantErr: "Docker actions are not allowed",
+		},
+		{
+			name: "rejects escaped Docker uses key",
+			workflow: `jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - "\u0075ses": docker://example.invalid/action:latest
+`,
+			wantErr: "Docker actions are not allowed",
+		},
+		{
+			name: "rejects Docker action alias",
+			workflow: `env:
+  docker-action: &docker-action docker://example.invalid/action:latest
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: *docker-action
+`,
+			wantErr: "Docker actions are not allowed",
+		},
+		{
+			name: "rejects Docker action alias key",
+			workflow: `env:
+  uses-key: &uses-key uses
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - *uses-key: docker://example.invalid/action:latest
+`,
+			wantErr: "Docker actions are not allowed",
+		},
+		{
+			name: "rejects unsafe checkout key",
+			workflow: `jobs:
+  unsafe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          "allow-unsafe-pr-checkout": true
+`,
+			wantErr: "allow-unsafe-pr-checkout must not be configured",
+		},
+		{
+			name: "rejects escaped unsafe checkout key",
+			workflow: `jobs:
+  unsafe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          "allow-unsafe-pr-check\u006fut": true
+`,
+			wantErr: "allow-unsafe-pr-checkout must not be configured",
+		},
+		{
+			name: "rejects aliased unsafe checkout key",
+			workflow: `env:
+  unsafe-key: &unsafe-key allow-unsafe-pr-checkout
+jobs:
+  unsafe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          *unsafe-key: true
+`,
+			wantErr: "allow-unsafe-pr-checkout must not be configured",
+		},
+		{
+			name: "rejects unpinned reusable workflow",
+			workflow: `jobs:
+  reusable:
+    uses: owner/repository/.github/workflows/reusable.yml@main
+`,
+			wantErr: "external action is not pinned to a full commit",
+		},
+		{
+			name: "rejects quoted unpinned uses key",
+			workflow: `jobs:
+  unpinned:
+    runs-on: ubuntu-latest
+    steps:
+      - "uses": actions/checkout@main
+`,
+			wantErr: "external action is not pinned to a full commit",
+		},
+		{
+			name: "requires checkout version annotation",
+			workflow: `jobs:
+  checkout:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+`,
+			wantErr: "expected # v7.0.0 annotation",
+		},
+		{
+			name: "requires setup go version annotation",
+			workflow: `jobs:
+  setup-go:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
+`,
+			wantErr: "expected # v7.0.0 annotation",
+		},
+		{
+			name: "requires reviewed setup go commit",
+			workflow: `jobs:
+  setup-go:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v7.0.0
+`,
+			wantErr: "expected actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e",
+		},
+		{
+			name: "rejects mixed case checkout reference",
+			workflow: `jobs:
+  checkout:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v7.0.0
+`,
+			wantErr: "expected actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+		},
+		{
+			name: "ignores env data named uses",
+			workflow: `env:
+  uses: not-an-action
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`,
+		},
+		{
+			name: "allows non-checkout input named allow unsafe checkout",
+			workflow: `jobs:
+  custom-action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: owner/repository@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        with:
+          allow-unsafe-pr-checkout: true
+`,
+		},
+		{
+			name: "rejects multiple YAML documents",
+			workflow: `jobs:
+  first:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+---
+name: second action-pins fixture
+on: workflow_dispatch
+jobs:
+  second:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: owner/repository@main
+`,
+			wantErr: "workflow must contain exactly one YAML document",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workflows := t.TempDir()
+			writeWorkflow(t, workflows, "baseline.yml", baselineWorkflow)
+			if tt.workflow != "" {
+				writeWorkflow(t, workflows, "fixture.yml", fixtureWorkflow(tt.workflow))
+			}
+
+			err := checkWorkflows(workflows)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("checkWorkflows() error = %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("checkWorkflows() succeeded, want error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("checkWorkflows() error = %q, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func fixtureWorkflow(body string) string {
+	return "name: action-pins fixture\non: workflow_dispatch\n" + body
+}
+
+func writeWorkflow(t *testing.T, dir, name, content string) {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/tools/actionpins/main_test.go
+++ b/tools/actionpins/main_test.go
@@ -249,6 +249,7 @@ jobs:
 				if err != nil {
 					t.Fatalf("checkWorkflows() error = %v", err)
 				}
+
 				return
 			}
 


### PR DESCRIPTION
## Why

The post-merge label-workflow canary for #58 passed, but the runner warned that
the pinned `actions/checkout` and `actions/setup-go` releases still target the
deprecated Node.js 20 runtime. GitHub temporarily forced them onto Node.js 24.

## What changed

- Upgrade every `actions/checkout` use to the reviewed, immutable v7.0.0 commit
  `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`.
- Upgrade every `actions/setup-go` use to the reviewed, immutable v7.0.0 commit
  `b7ad1dad31e06c5925ef5d2fc7ad053ef454303e`.
- Add a dedicated action-pin regression job backed by a small Go checker. It
  structurally decodes workflow YAML, requires a full immutable Git commit pin
  for every external step or reusable workflow, rejects Docker action
  references, enforces the two reviewed first-party baselines, and forbids
  checkout's `allow-unsafe-pr-checkout` escape hatch in every YAML spelling.

Both action manifests use Node.js 24. Checkout v7 also refuses by default to
check out fork PR code from `pull_request_target` or `workflow_run`; this
repository does not opt out of that guard.

## Validation

- Retained structural policy tests: the policy accepts the reviewed baseline
  and local action references; and rejects plain, quoted, escaped, and
  aliased Docker action references; case-variant first-party references;
  quoted, escaped, and aliased unsafe-checkout keys; unpinned reusable
  workflows; unpinned first-party actions; and multiple YAML documents. They
  also prove that unrelated `env` and non-checkout `with` data is ignored.
- `go test -race -covermode=atomic ./...`
- Go action-pin policy tests and the label-workflow regression script
- ShellCheck and Bash syntax validation
- YAML parsing and `actionlint` v1.7.7
- `git diff --check`

## Rollout

Ordinary PR checks exercise the new actions directly. After merge, draft
canary #57 will be edited once more to exercise the trusted
`pull_request_target` classifier on the default-branch workflow; it will then
be closed without merging.