### PR TITLE
ci(lint): update golangci-lint action to v9.3.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,6 +39,6 @@ jobs:
           check-latest: true
 
       - name: Lint
-        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.11.4


### PR DESCRIPTION
## Why

This removes the last Node 20 deprecation warning left after PR #59 by updating the `golangci/golangci-lint-action` runner.

## Change

- Updates only `.github/workflows/lint.yml`.
- Replaces the v7.0.1 pin with the immutable `ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a` pin for `golangci/golangci-lint-action` v9.3.0.
- The official `action.yml` at that SHA declares `runs.using: node24`.
- Keeps the existing supported `version: v2.11.4` input unchanged.

## Validation

- `actionlint` workflow validation
- `go run ./tools/actionpins`
- `go test ./...`
- `git diff --check`

Scope is intentionally limited to this single action pin update.
