### PR TITLE
fix(parser): accept terminal line endings

### DIFF
--- a/parser/line_endings.go
+++ b/parser/line_endings.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright © 2026- Leonardo Di Donato <leodidonato@gmail.com>
+
+package parser
+
+// trimTerminalLineEndings removes a trailing sequence of LF and CRLF tokens
+// after non-whitespace content. It deliberately leaves trailing whitespace
+// and non-empty lines for the parser to reject normally.
+func trimTerminalLineEndings(input []byte) []byte {
+	end := len(input)
+	for end > 0 && input[end-1] == '\n' {
+		end--
+		if end > 0 && input[end-1] == '\r' {
+			end--
+		}
+	}
+	if end == len(input) || end == 0 || input[end-1] == ' ' || input[end-1] == '\t' {
+		return input
+	}
+
+	return input[:end]
+}

--- a/parser/machine.go
+++ b/parser/machine.go
@@ -257,6 +257,8 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		}
 	}
 
+	input = trimTerminalLineEndings(input)
+
 	m.data = input
 	m.p = 0
 	m.pb = 0

--- a/parser/machine.go.rl
+++ b/parser/machine.go.rl
@@ -556,6 +556,8 @@ func (m *machine) Parse(input []byte) (conventionalcommits.Message, error) {
 		}
 	}
 
+	input = trimTerminalLineEndings(input)
+
 	m.data = input
 	m.p = 0
 	m.pb = 0

--- a/parser/machine_test.go
+++ b/parser/machine_test.go
@@ -46,8 +46,13 @@ func TestParseTerminalLineEndings(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "trailing tab is not normalized",
+			input:   header + "\t\n",
+			wantErr: true,
+		},
+		{
 			name:    "non-empty trailing line is not normalized",
-			input:   header + "\nnot a body",
+			input:   header + "\nnot a body\n",
 			wantErr: true,
 		},
 	}
@@ -88,13 +93,18 @@ func TestParseTerminalLineEndings(t *testing.T) {
 	}
 }
 
-func TestParsePreservesTerminalCarriageReturn(t *testing.T) {
-	message, err := NewMachine().Parse([]byte("feat: description\r"))
+func TestParsePreservesCarriageReturnContent(t *testing.T) {
+	for _, input := range []string{
+		"feat: description\r",
+		"feat: description\r\r\n",
+	} {
+		message, err := NewMachine().Parse([]byte(input))
 
-	require.NoError(t, err)
-	commit, ok := message.(*conventionalcommits.ConventionalCommit)
-	require.True(t, ok)
-	assert.Equal(t, "description\r", commit.Description)
+		require.NoError(t, err)
+		commit, ok := message.(*conventionalcommits.ConventionalCommit)
+		require.True(t, ok)
+		assert.Equal(t, "description\r", commit.Description)
+	}
 }
 
 func TestMachineParseWithFalcoTypes(t *testing.T) {

--- a/parser/machine_test.go
+++ b/parser/machine_test.go
@@ -18,6 +18,85 @@ func TestMachineParse(t *testing.T) {
 	runner(t, "minimaltypes", testCases, WithTypes(conventionalcommits.TypesMinimal))
 }
 
+func TestParseTerminalLineEndings(t *testing.T) {
+	t.Parallel()
+
+	const header = "feat(NOSCOPE): some great feature"
+
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:  "single LF",
+			input: header + "\n",
+		},
+		{
+			name:  "single CRLF",
+			input: header + "\r\n",
+		},
+		{
+			name:  "mixed terminal line endings",
+			input: header + "\r\n\n\r\n",
+		},
+		{
+			name:    "trailing space is not normalized",
+			input:   header + " \n",
+			wantErr: true,
+		},
+		{
+			name:    "non-empty trailing line is not normalized",
+			input:   header + "\nnot a body",
+			wantErr: true,
+		},
+	}
+
+	modes := []struct {
+		name string
+		opts []conventionalcommits.MachineOption
+	}{
+		{name: "default"},
+		{name: "best-effort", opts: []conventionalcommits.MachineOption{WithBestEffort()}},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			for _, mode := range modes {
+				mode := mode
+				t.Run(mode.name, func(t *testing.T) {
+					message, err := NewMachine(mode.opts...).Parse([]byte(tc.input))
+					if tc.wantErr {
+						require.Error(t, err)
+
+						return
+					}
+
+					require.NoError(t, err)
+					require.NotNil(t, message)
+
+					commit, ok := message.(*conventionalcommits.ConventionalCommit)
+					require.True(t, ok)
+					assert.Equal(t, "feat", commit.Type)
+					require.NotNil(t, commit.Scope)
+					assert.Equal(t, "noscope", *commit.Scope)
+					assert.Equal(t, "some great feature", commit.Description)
+				})
+			}
+		})
+	}
+}
+
+func TestParsePreservesTerminalCarriageReturn(t *testing.T) {
+	message, err := NewMachine().Parse([]byte("feat: description\r"))
+
+	require.NoError(t, err)
+	commit, ok := message.(*conventionalcommits.ConventionalCommit)
+	require.True(t, ok)
+	assert.Equal(t, "description\r", commit.Description)
+}
+
 func TestMachineParseWithFalcoTypes(t *testing.T) {
 	runner(t, "falcotypes", testCasesForFalcoTypes, WithTypes(conventionalcommits.TypesFalco))
 }

--- a/parser/testcases.go
+++ b/parser/testcases.go
@@ -517,13 +517,11 @@ var testCases = []testCase{
 		fmt.Sprintf(ErrMissingBlankLineAtBeginning+ColumnPositionTemplate, 15),
 		nil,
 	},
-	// INVALID / newline in the description
-	// VALID / until the newline
+	// VALID / terminal line ending
 	{
 		"description-ending-with-single-newline",
 		[]byte("feat(az)!: bla\x0A"),
-		false,
-		nil,
+		true,
 		&conventionalcommits.ConventionalCommit{
 			Type:        "feat",
 			Scope:       cctesting.StringAddress("az"),
@@ -531,7 +529,14 @@ var testCases = []testCase{
 			Description: "bla",
 			TypeConfig:  0,
 		},
-		fmt.Sprintf(ErrMissingBlankLineAtBeginning+ColumnPositionTemplate, 15),
+		&conventionalcommits.ConventionalCommit{
+			Type:        "feat",
+			Scope:       cctesting.StringAddress("az"),
+			Exclamation: true,
+			Description: "bla",
+			TypeConfig:  0,
+		},
+		"",
 		nil,
 	},
 	// VALID / multi-line body is valid (after a blank line)
@@ -2024,13 +2029,11 @@ var testCasesForFalcoTypes = []testCase{
 		fmt.Sprintf(ErrMissingBlankLineAtBeginning+ColumnPositionTemplate, 15),
 		nil,
 	},
-	// INVALID / newline in the description
-	// VALID / until the newline
+	// VALID / terminal line ending
 	{
 		"description-ending-with-single-newline",
 		[]byte("docs(az)!: bla\x0A"),
-		false,
-		nil,
+		true,
 		&conventionalcommits.ConventionalCommit{
 			Type:        "docs",
 			Scope:       cctesting.StringAddress("az"),
@@ -2038,7 +2041,14 @@ var testCasesForFalcoTypes = []testCase{
 			Description: "bla",
 			TypeConfig:  2,
 		},
-		fmt.Sprintf(ErrMissingBlankLineAtBeginning+ColumnPositionTemplate, 15),
+		&conventionalcommits.ConventionalCommit{
+			Type:        "docs",
+			Scope:       cctesting.StringAddress("az"),
+			Exclamation: true,
+			Description: "bla",
+			TypeConfig:  2,
+		},
+		"",
 		nil,
 	},
 	// VALID
@@ -2846,13 +2856,11 @@ var testCasesForConventionalTypes = []testCase{
 		fmt.Sprintf(ErrMissingBlankLineAtBeginning+ColumnPositionTemplate, 15),
 		nil,
 	},
-	// INVALID / newline in the description
-	// VALID / until the newline
+	// VALID / terminal line ending
 	{
 		"description-ending-with-single-newline",
 		[]byte("perf(at)!: rrr\x0A"),
-		false,
-		nil,
+		true,
 		&conventionalcommits.ConventionalCommit{
 			Type:        "perf",
 			Scope:       cctesting.StringAddress("at"),
@@ -2860,7 +2868,14 @@ var testCasesForConventionalTypes = []testCase{
 			Description: "rrr",
 			TypeConfig:  1,
 		},
-		fmt.Sprintf(ErrMissingBlankLineAtBeginning+ColumnPositionTemplate, 15),
+		&conventionalcommits.ConventionalCommit{
+			Type:        "perf",
+			Scope:       cctesting.StringAddress("at"),
+			Exclamation: true,
+			Description: "rrr",
+			TypeConfig:  1,
+		},
+		"",
 		nil,
 	},
 	// VALID


### PR DESCRIPTION
Fixes #39

Accept a terminal sequence of LF and CRLF line endings after an otherwise valid commit message.

The Ragel grammar treats LF as structural input, so an editor-added final newline after the description previously entered the optional remainder and failed with `missing a blank line`. The parser now normalizes only a well-formed terminal LF/CRLF suffix before initializing parser state.

The boundary is deliberately narrow:
- terminal LF, CRLF, and mixed LF/CRLF suffixes are accepted;
- trailing spaces and non-empty extra content remain parser errors;
- pre-existing bare CR behavior is preserved;
- strict UTF-8 still validates the original bytes before normalization.

Validated with:
- `go test -race -covermode=atomic ./...`
- `go run ./tools/actionpins`
- `.github/scripts/test-label-workflow.sh`
- `golangci-lint run`
- regenerated `parser/machine.go` from `parser/machine.go.rl`.
